### PR TITLE
Add draft approval logic and tests

### DIFF
--- a/cms/workflow.py
+++ b/cms/workflow.py
@@ -4,3 +4,16 @@ def check_required_metadata(content):
     for field in required_fields:
         if field not in content["metadata"] or content["metadata"][field] is None:
             raise KeyError(f"Missing required metadata field: {field}")
+
+
+def request_approval(content, user, timestamp):
+    """Mark the given content as awaiting admin approval."""
+    content["metadata"]["draft_requested_by"] = user["uuid"]
+    content["metadata"]["draft_requested_at"] = timestamp
+    content["state"] = "AwaitingApproval"
+    return content
+
+
+def pending_approvals(contents):
+    """Return items that are awaiting admin approval."""
+    return [item for item in contents if item.get("state") == "AwaitingApproval"]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,7 +2,7 @@ import json
 import unittest
 
 from cms.data import seed_users, sample_content
-from cms.workflow import check_required_metadata
+from cms.workflow import check_required_metadata, pending_approvals
 
 
 class TestCMSWorkflow(unittest.TestCase):
@@ -10,6 +10,12 @@ class TestCMSWorkflow(unittest.TestCase):
         self.users = seed_users()
         self.content_html = sample_content(self.users)
         self.draft_content_html = self.content_html.copy()
+
+    def test_editor_does_not_submit_content_admin_sees_nothing(self):
+        """Content saved as draft should not appear in admin approval queue."""
+        contents = [self.content_html]
+        pending = pending_approvals(contents)
+        self.assertEqual(pending, [], "Admin should not see approval requests")
 
     def test_export_json_missing_metadata(self):
         """Test exporting content that has missing metadata fields."""


### PR DESCRIPTION
## Summary
- implement `request_approval` and `pending_approvals` helpers
- cover new logic with test ensuring drafts aren't visible to admin

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684532a41e648322851d41761f63d8e0