### PR TITLE
Add test HTTP server and CRUD API tests

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -1,0 +1,77 @@
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from urllib.parse import urlparse
+
+
+class SimpleCRUDHandler(BaseHTTPRequestHandler):
+    store = {}
+
+    def _send_json(self, data, status=200):
+        response = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/content/"):
+            uuid = parsed.path.split("/")[-1]
+            item = self.store.get(uuid)
+            if item is None:
+                self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(item)
+        else:
+            self._send_json({"error": "not found"}, status=404)
+
+    def do_POST(self):
+        if self.path != "/content":
+            self._send_json({"error": "not found"}, status=404)
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        item = json.loads(body)
+        uuid = item.get("uuid")
+        if not uuid:
+            self._send_json({"error": "uuid required"}, status=400)
+            return
+        self.store[uuid] = item
+        self._send_json(item, status=201)
+
+    def do_PUT(self):
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/content/"):
+            uuid = parsed.path.split("/")[-1]
+            if uuid not in self.store:
+                self._send_json({"error": "not found"}, status=404)
+                return
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            item = json.loads(body)
+            self.store[uuid] = item
+            self._send_json(item)
+        else:
+            self._send_json({"error": "not found"}, status=404)
+
+    def do_DELETE(self):
+        parsed = urlparse(self.path)
+        if parsed.path.startswith("/content/"):
+            uuid = parsed.path.split("/")[-1]
+            if uuid in self.store:
+                del self.store[uuid]
+                self._send_json({"deleted": uuid})
+            else:
+                self._send_json({"error": "not found"}, status=404)
+        else:
+            self._send_json({"error": "not found"}, status=404)
+
+
+def start_test_server(port=0):
+    """Start the CRUD HTTP server on a background thread."""
+    server = HTTPServer(("localhost", port), SimpleCRUDHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,8 +1,15 @@
 import json
+import os
+import sys
 import unittest
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from cms.data import seed_users, sample_content
 from cms.workflow import check_required_metadata, pending_approvals
+from cms.api import start_test_server
 
 
 class TestCMSWorkflow(unittest.TestCase):
@@ -37,6 +44,57 @@ class TestCMSWorkflow(unittest.TestCase):
         with self.assertRaises(KeyError, msg="Missing required metadata fields."):
             check_required_metadata(invalid_content)
             json.dumps(invalid_content)
+
+
+class TestCMSAPICRUD(unittest.TestCase):
+    def setUp(self):
+        self.server, self.thread = start_test_server()
+        self.base_url = f"http://localhost:{self.server.server_port}"
+        self.users = seed_users()
+        self.content = sample_content(self.users)
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.thread.join()
+
+    def _request(self, method, path, data=None):
+        url = self.base_url + path
+        headers = {"Content-Type": "application/json"}
+        if data is not None:
+            data = json.dumps(data).encode()
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.status, json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode())
+
+    def test_crud_flow(self):
+        # CREATE
+        status, body = self._request("POST", "/content", self.content)
+        self.assertEqual(status, 201)
+        self.assertEqual(body["uuid"], self.content["uuid"])
+
+        # READ
+        status, body = self._request("GET", f"/content/{self.content['uuid']}")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["uuid"], self.content["uuid"])
+
+        # UPDATE
+        updated = body.copy()
+        updated["title"] = "Updated"
+        status, body = self._request("PUT", f"/content/{updated['uuid']}", updated)
+        self.assertEqual(status, 200)
+        self.assertEqual(body["title"], "Updated")
+
+        # DELETE
+        status, body = self._request("DELETE", f"/content/{updated['uuid']}")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["deleted"], updated["uuid"])
+
+        # Confirm deletion
+        status, _ = self._request("GET", f"/content/{updated['uuid']}")
+        self.assertEqual(status, 404)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a simple JSON CRUD HTTP server for testing
- ensure tests adjust `sys.path` for package imports
- add API-based CRUD test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684534542d148322a632d0a42c6c9bdc