### PR TITLE
Add pytest coverage for API workflow

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,101 +1,110 @@
 import json
 import os
 import sys
-import unittest
 import urllib.error
 import urllib.request
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from cms.data import seed_users, sample_content
-from cms.workflow import check_required_metadata, pending_approvals
+from cms.workflow import (
+    check_required_metadata,
+    pending_approvals,
+    request_approval,
+)
 from cms.api import start_test_server
 
 
-class TestCMSWorkflow(unittest.TestCase):
-    def setUp(self):
-        self.users = seed_users()
-        self.content_html = sample_content(self.users)
-        self.draft_content_html = self.content_html.copy()
-
-    def test_editor_does_not_submit_content_admin_sees_nothing(self):
-        """Content saved as draft should not appear in admin approval queue."""
-        contents = [self.content_html]
-        pending = pending_approvals(contents)
-        self.assertEqual(pending, [], "Admin should not see approval requests")
-
-    def test_export_json_missing_metadata(self):
-        """Test exporting content that has missing metadata fields."""
-        invalid_content = {
-            "uuid": "12350",
-            "title": "Missing Metadata Content",
-            "type": "HTML",
-            "metadata": {
-                "created_by": self.users["editor"]["uuid"],
-                # Missing 'created_at' and 'timestamps'
-            },
-            "state": "Draft",
-            "archived": False,
-        }
-
-        with self.assertRaises(KeyError, msg="Missing required metadata fields."):
-            check_required_metadata(invalid_content)
-
-        with self.assertRaises(KeyError, msg="Missing required metadata fields."):
-            check_required_metadata(invalid_content)
-            json.dumps(invalid_content)
+@pytest.fixture()
+def users():
+    return seed_users()
 
 
-class TestCMSAPICRUD(unittest.TestCase):
-    def setUp(self):
-        self.server, self.thread = start_test_server()
-        self.base_url = f"http://localhost:{self.server.server_port}"
-        self.users = seed_users()
-        self.content = sample_content(self.users)
-
-    def tearDown(self):
-        self.server.shutdown()
-        self.thread.join()
-
-    def _request(self, method, path, data=None):
-        url = self.base_url + path
-        headers = {"Content-Type": "application/json"}
-        if data is not None:
-            data = json.dumps(data).encode()
-        req = urllib.request.Request(url, data=data, headers=headers, method=method)
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return resp.status, json.loads(resp.read())
-        except urllib.error.HTTPError as e:
-            return e.code, json.loads(e.read().decode())
-
-    def test_crud_flow(self):
-        # CREATE
-        status, body = self._request("POST", "/content", self.content)
-        self.assertEqual(status, 201)
-        self.assertEqual(body["uuid"], self.content["uuid"])
-
-        # READ
-        status, body = self._request("GET", f"/content/{self.content['uuid']}")
-        self.assertEqual(status, 200)
-        self.assertEqual(body["uuid"], self.content["uuid"])
-
-        # UPDATE
-        updated = body.copy()
-        updated["title"] = "Updated"
-        status, body = self._request("PUT", f"/content/{updated['uuid']}", updated)
-        self.assertEqual(status, 200)
-        self.assertEqual(body["title"], "Updated")
-
-        # DELETE
-        status, body = self._request("DELETE", f"/content/{updated['uuid']}")
-        self.assertEqual(status, 200)
-        self.assertEqual(body["deleted"], updated["uuid"])
-
-        # Confirm deletion
-        status, _ = self._request("GET", f"/content/{updated['uuid']}")
-        self.assertEqual(status, 404)
+@pytest.fixture()
+def content_html(users):
+    return sample_content(users)
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture()
+def api_server():
+    server, thread = start_test_server()
+    base_url = f"http://localhost:{server.server_port}"
+    yield base_url
+    server.shutdown()
+    thread.join()
+
+
+def _request(base_url, method, path, data=None):
+    url = base_url + path
+    headers = {"Content-Type": "application/json"}
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode())
+
+
+def test_editor_does_not_submit_content_admin_sees_nothing(content_html):
+    contents = [content_html]
+    pending = pending_approvals(contents)
+    assert pending == []
+
+
+def test_request_approval_adds_to_pending(content_html, users):
+    timestamp = "2025-06-09T10:00:00"
+    request_approval(content_html, users["editor"], timestamp)
+    assert pending_approvals([content_html]) == [content_html]
+
+
+def test_check_required_metadata_success(content_html):
+    check_required_metadata(content_html)
+
+
+def test_export_json_missing_metadata(users):
+    invalid_content = {
+        "uuid": "12350",
+        "title": "Missing Metadata Content",
+        "type": "HTML",
+        "metadata": {
+            "created_by": users["editor"]["uuid"],
+            # Missing 'created_at' and 'timestamps'
+        },
+        "state": "Draft",
+        "archived": False,
+    }
+
+    with pytest.raises(KeyError):
+        check_required_metadata(invalid_content)
+
+
+def test_crud_flow(api_server, content_html):
+    # CREATE
+    status, body = _request(api_server, "POST", "/content", content_html)
+    assert status == 201
+    assert body["uuid"] == content_html["uuid"]
+
+    # READ
+    status, body = _request(api_server, "GET", f"/content/{content_html['uuid']}")
+    assert status == 200
+    assert body["uuid"] == content_html["uuid"]
+
+    # UPDATE
+    updated = body.copy()
+    updated["title"] = "Updated"
+    status, body = _request(api_server, "PUT", f"/content/{updated['uuid']}", updated)
+    assert status == 200
+    assert body["title"] == "Updated"
+
+    # DELETE
+    status, body = _request(api_server, "DELETE", f"/content/{updated['uuid']}")
+    assert status == 200
+    assert body["deleted"] == updated["uuid"]
+
+    # Confirm deletion
+    status, _ = _request(api_server, "GET", f"/content/{updated['uuid']}")
+    assert status == 404


### PR DESCRIPTION
## Summary
- convert unittest-based tests to pytest functions
- add fixtures and additional tests covering workflow approval
- ensure API CRUD operations still covered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453533083c8322aafcc9c899631807