### PR TITLE
Add draft lock check

### DIFF
--- a/cms/workflow.py
+++ b/cms/workflow.py
@@ -17,3 +17,23 @@ def request_approval(content, user, timestamp):
 def pending_approvals(contents):
     """Return items that are awaiting admin approval."""
     return [item for item in contents if item.get("state") == "AwaitingApproval"]
+
+
+def start_draft(content, user, timestamp):
+    """Begin editing a content item in Draft state.
+
+    If another user already has the item in Draft status, raise a
+    PermissionError indicating who is editing it.
+    """
+    current_editor = content["metadata"].get("edited_by")
+    if (
+        content.get("state") == "Draft"
+        and current_editor is not None
+        and current_editor != user["uuid"]
+    ):
+        raise PermissionError(f"User {current_editor} has it in draft status")
+
+    content["metadata"]["edited_by"] = user["uuid"]
+    content["metadata"]["edited_at"] = timestamp
+    content["state"] = "Draft"
+    return content

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -13,6 +13,7 @@ from cms.workflow import (
     check_required_metadata,
     pending_approvals,
     request_approval,
+    start_draft,
 )
 from cms.api import start_test_server
 
@@ -80,6 +81,16 @@ def test_export_json_missing_metadata(users):
 
     with pytest.raises(KeyError):
         check_required_metadata(invalid_content)
+
+
+def test_draft_locked_for_other_user(content_html, users):
+    ts1 = "2025-06-10T09:00:00"
+    start_draft(content_html, users["editor"], ts1)
+
+    with pytest.raises(PermissionError) as excinfo:
+        start_draft(content_html, users["admin"], "2025-06-10T10:00:00")
+
+    assert users["editor"]["uuid"] in str(excinfo.value)
 
 
 def test_crud_flow(api_server, content_html):


### PR DESCRIPTION
## Summary
- prevent editing of a draft if another user has it locked
- test draft locking behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845376896d88322ad390a390781a3ce