### PR TITLE
Add ContentType enum

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -1,3 +1,6 @@
+from .types import ContentType
+
+
 def seed_users():
     """Return a dictionary of example users."""
     return {
@@ -11,7 +14,7 @@ def sample_content(users):
     return {
         "uuid": "12345",
         "title": "Sample HTML Content",
-        "type": "HTML",
+        "type": ContentType.HTML.value,
         "metadata": {
             "created_by": users["editor"]["uuid"],
             "created_at": "2025-06-08T12:00:00",

--- a/cms/types.py
+++ b/cms/types.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class ContentType(str, Enum):
+    """Enumerate supported content types."""
+
+    HTML = "html"
+    PDF = "pdf"
+    OFFICE_ADDRESS = "office address"
+    EVENT_SCHEDILW = "event schedilw"

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cms.types import ContentType
+
+
+def test_supported_content_types():
+    expected = {"html", "pdf", "office address", "event schedilw"}
+    assert len(ContentType) == 4
+    assert {item.value for item in ContentType} == expected


### PR DESCRIPTION
## Summary
- add `ContentType` enum listing the four supported content types
- use the enum for sample content
- add tests for `ContentType`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453971deac8322940047494740fcc8