### PR TITLE
Enforce draft state on creation

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -180,9 +180,11 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             item_uuid = str(uuid.uuid4())
             item["uuid"] = item_uuid
 
+        # all newly created content should begin in Draft state
+        item["state"] = "Draft"
+
         # PDFs should start in Draft/pre-submission state
         if item.get("type") == "pdf":
-            item["state"] = "Draft"
             item["pre_submission"] = True
 
         self._ensure_revision_structure(item)

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,7 +22,7 @@ Authorization: Bearer <token>
 Returns a list of supported content types.
 
 ### `POST /content`
-Create a new content item. The body must include a `type` field with one of the supported values and `metadata` containing at least `created_by`, `created_at` and `timestamps`.
+Create a new content item. The body must include a `type` field with one of the supported values and `metadata` containing at least `created_by`, `created_at` and `timestamps`. Regardless of any provided value, newly created items are stored in the `Draft` state.
 
 ### `GET /content/<uuid>`
 Retrieve a stored content item.

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -45,7 +45,7 @@ classDiagram
 - **revisions** – list of revision objects. Each revision includes a `uuid` and `last_updated` timestamp.
 - **published_revision** – UUID of the currently published revision.
 - **draft_revision** – UUID of the most recent draft revision.
-- **state** – workflow state such as `Draft` or `AwaitingApproval`.
+- **state** – workflow state such as `Draft` or `AwaitingApproval`. Newly created items always start in the `Draft` state.
 - **archived** – set to `true` if the item is no longer active.
 - **file** – base64 encoded file contents (PDF only).
 - **pre_submission** – boolean that indicates a newly created PDF has not yet been submitted for approval.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -89,6 +89,21 @@ def test_check_required_metadata_success(api_server, content_html, auth_token):
     assert body == {"ok": True}
 
 
+def test_content_created_without_state_starts_in_draft(api_server, users, auth_token):
+    content = sample_content(users)
+    content.pop("state", None)
+    status, body = _request(api_server, "POST", "/content", content, token=auth_token)
+    assert status == 201
+    assert body["state"] == "Draft"
+
+
+def test_content_state_overridden_to_draft(api_server, content_html, auth_token):
+    content_html["state"] = "Published"
+    status, body = _request(api_server, "POST", "/content", content_html, token=auth_token)
+    assert status == 201
+    assert body["state"] == "Draft"
+
+
 def test_export_json_missing_metadata(api_server, users, auth_token):
     invalid_content = {
         "uuid": "12350",


### PR DESCRIPTION
## Summary
- set content state to `Draft` when created
- document new default draft state for POST /content
- mention draft default in data structure docs
- test that content starts in draft state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456938d748832297f260cb06740775