### PR TITLE
Implement archiving instead of deleting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The server listens for JSON requests on endpoints such as:
 - `POST /content` – create a new content item.
 - `GET /content/<uuid>` – retrieve a stored item.
 - `PUT /content/<uuid>` – update an item.
-- `DELETE /content/<uuid>` – remove an item.
+- `DELETE /content/<uuid>` – archive an item without removing it.
 - `POST /test-token` – obtain a test API token for a username.
 
 All content endpoints require an `Authorization` header of the form `Bearer <token>`.

--- a/cms/api.py
+++ b/cms/api.py
@@ -5,7 +5,12 @@ from threading import Thread
 from urllib.parse import urlparse
 
 from .types import ContentType
-from .workflow import check_required_metadata, request_approval, start_draft
+from .workflow import (
+    check_required_metadata,
+    request_approval,
+    start_draft,
+    archive_content,
+)
 
 
 class SimpleCRUDHandler(BaseHTTPRequestHandler):
@@ -235,8 +240,10 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
                 return
             uuid = parsed.path.split("/")[-1]
             if uuid in self.store:
-                del self.store[uuid]
-                self._send_json({"deleted": uuid})
+                item = self.store[uuid]
+                archive_content(item)
+                self.store[uuid] = item
+                self._send_json(item)
             else:
                 self._send_json({"error": "not found"}, status=404)
         else:

--- a/cms/workflow.py
+++ b/cms/workflow.py
@@ -37,3 +37,10 @@ def start_draft(content, user, timestamp):
     content["metadata"]["edited_at"] = timestamp
     content["state"] = "Draft"
     return content
+
+
+def archive_content(content):
+    """Mark a content item as archived."""
+    content["state"] = "Archived"
+    content["archived"] = True
+    return content

--- a/docs/API.md
+++ b/docs/API.md
@@ -31,7 +31,7 @@ Retrieve a stored content item.
 Update a content item. The `type` and entire `metadata` block are immutable via this endpoint.
 
 ### `DELETE /content/<uuid>`
-Remove a content item.
+Archive a content item. Items are not removed from the system.
 
 ### `POST /content/<uuid>/start-draft`
 Begin editing an item. The request body should contain `user_uuid` and `timestamp`. A `403` is returned if another user already has the item in draft status.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -165,11 +165,13 @@ def test_crud_flow(api_server, content_html, auth_token):
     assert status == 200
     assert body["title"] == "Updated"
 
-    # DELETE
+    # ARCHIVE
     status, body = _request(api_server, "DELETE", f"/content/{updated['uuid']}", token=auth_token)
     assert status == 200
-    assert body["deleted"] == updated["uuid"]
+    assert body["archived"] is True
+    assert body["state"] == "Archived"
 
-    # Confirm deletion
-    status, _ = _request(api_server, "GET", f"/content/{updated['uuid']}", token=auth_token)
-    assert status == 404
+    # Confirm archived item is still retrievable
+    status, body = _request(api_server, "GET", f"/content/{updated['uuid']}", token=auth_token)
+    assert status == 200
+    assert body["archived"] is True


### PR DESCRIPTION
## Summary
- change delete endpoint to archive content
- add `archive_content` workflow helper
- update docs for archive behaviour
- update CRUD workflow test to check archiving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456a3a66d08322bae9f670bb94479a