### PR TITLE
Refactor metadata into unified content dataclasses

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -1,4 +1,5 @@
 from .types import ContentType
+from .models import HTMLContent, Revision
 
 
 def seed_users():
@@ -13,26 +14,14 @@ def sample_content(users):
     """Create example HTML content using the provided users."""
     timestamp = "2025-06-08T12:00:00"
     revision_uuid = "rev-12345"
-    return {
-        "uuid": "12345",
-        "title": "Sample HTML Content",
-        "type": ContentType.HTML.value,
-        "metadata": {
-            "created_by": users["editor"]["uuid"],
-            "created_at": timestamp,
-            "edited_by": None,
-            "edited_at": None,
-            "draft_requested_by": None,
-            "draft_requested_at": None,
-            "approved_by": None,
-            "approved_at": None,
-            "timestamps": timestamp,
-        },
-        "revisions": [
-            {"uuid": revision_uuid, "last_updated": timestamp}
-        ],
-        "published_revision": revision_uuid,
-        "draft_revision": revision_uuid,
-        "state": "Draft",
-        "archived": False,
-    }
+    revision = Revision(uuid=revision_uuid, last_updated=timestamp)
+    return HTMLContent(
+        uuid="12345",
+        title="Sample HTML Content",
+        created_by=users["editor"]["uuid"],
+        created_at=timestamp,
+        timestamps=timestamp,
+        revisions=[revision],
+        published_revision=revision_uuid,
+        draft_revision=revision_uuid,
+    )

--- a/cms/models.py
+++ b/cms/models.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field, asdict
+from typing import List, Optional
+from .types import ContentType
+
+@dataclass
+class Revision:
+    uuid: str
+    last_updated: str
+
+@dataclass
+class Content:
+    uuid: str
+    title: str
+    type: ContentType = field(init=False)
+    created_by: str
+    created_at: str
+    edited_by: Optional[str] = None
+    edited_at: Optional[str] = None
+    draft_requested_by: Optional[str] = None
+    draft_requested_at: Optional[str] = None
+    approved_by: Optional[str] = None
+    approved_at: Optional[str] = None
+    timestamps: str = ""
+    revisions: List[Revision] = field(default_factory=list)
+    published_revision: Optional[str] = None
+    draft_revision: Optional[str] = None
+    state: str = "Draft"
+    archived: bool = False
+    file: Optional[str] = None
+    pre_submission: Optional[bool] = None
+
+    def to_dict(self):
+        data = asdict(self)
+        data["type"] = self.type.value
+        return data
+
+@dataclass
+class HTMLContent(Content):
+    type: ContentType = field(default=ContentType.HTML, init=False)
+
+@dataclass
+class PDFContent(Content):
+    type: ContentType = field(default=ContentType.PDF, init=False)
+
+@dataclass
+class OfficeAddressContent(Content):
+    type: ContentType = field(default=ContentType.OFFICE_ADDRESS, init=False)
+
+@dataclass
+class EventScheduleContent(Content):
+    type: ContentType = field(default=ContentType.EVENT_SCHEDULE, init=False)

--- a/cms/workflow.py
+++ b/cms/workflow.py
@@ -1,22 +1,48 @@
+from .models import Content
+
+
+def _get_metadata_value(content, field):
+    if isinstance(content, Content):
+        return getattr(content, field, None)
+    if field in content:
+        return content.get(field)
+    return content.get("metadata", {}).get(field)
+
+
 def check_required_metadata(content):
     """Ensure content contains required metadata fields."""
     required_fields = ["created_by", "created_at", "timestamps"]
     for field in required_fields:
-        if field not in content["metadata"] or content["metadata"][field] is None:
+        if _get_metadata_value(content, field) is None:
             raise KeyError(f"Missing required metadata field: {field}")
 
 
 def request_approval(content, user, timestamp):
     """Mark the given content as awaiting admin approval."""
-    content["metadata"]["draft_requested_by"] = user["uuid"]
-    content["metadata"]["draft_requested_at"] = timestamp
-    content["state"] = "AwaitingApproval"
+    if isinstance(content, Content):
+        content.draft_requested_by = user["uuid"]
+        content.draft_requested_at = timestamp
+        content.state = "AwaitingApproval"
+    else:
+        if "draft_requested_by" in content or "metadata" not in content:
+            content["draft_requested_by"] = user["uuid"]
+            content["draft_requested_at"] = timestamp
+        else:
+            content.setdefault("metadata", {})
+            content["metadata"]["draft_requested_by"] = user["uuid"]
+            content["metadata"]["draft_requested_at"] = timestamp
+        content["state"] = "AwaitingApproval"
     return content
 
 
 def pending_approvals(contents):
     """Return items that are awaiting admin approval."""
-    return [item for item in contents if item.get("state") == "AwaitingApproval"]
+    result = []
+    for item in contents:
+        state = item.state if isinstance(item, Content) else item.get("state")
+        if state == "AwaitingApproval":
+            result.append(item)
+    return result
 
 
 def start_draft(content, user, timestamp):
@@ -25,22 +51,43 @@ def start_draft(content, user, timestamp):
     If another user already has the item in Draft status, raise a
     PermissionError indicating who is editing it.
     """
-    current_editor = content["metadata"].get("edited_by")
-    if (
-        content.get("state") == "Draft"
-        and current_editor is not None
-        and current_editor != user["uuid"]
-    ):
-        raise PermissionError(f"User {current_editor} has it in draft status")
-
-    content["metadata"]["edited_by"] = user["uuid"]
-    content["metadata"]["edited_at"] = timestamp
-    content["state"] = "Draft"
+    if isinstance(content, Content):
+        current_editor = content.edited_by
+        if (
+            content.state == "Draft"
+            and current_editor is not None
+            and current_editor != user["uuid"]
+        ):
+            raise PermissionError(f"User {current_editor} has it in draft status")
+        content.edited_by = user["uuid"]
+        content.edited_at = timestamp
+        content.state = "Draft"
+    else:
+        current_editor = content.get("edited_by")
+        if current_editor is None and "metadata" in content:
+            current_editor = content["metadata"].get("edited_by")
+        if (
+            content.get("state") == "Draft"
+            and current_editor is not None
+            and current_editor != user["uuid"]
+        ):
+            raise PermissionError(f"User {current_editor} has it in draft status")
+        if "edited_by" in content or "metadata" not in content:
+            content["edited_by"] = user["uuid"]
+            content["edited_at"] = timestamp
+        else:
+            content["metadata"]["edited_by"] = user["uuid"]
+            content["metadata"]["edited_at"] = timestamp
+        content["state"] = "Draft"
     return content
 
 
 def archive_content(content):
     """Mark a content item as archived."""
-    content["state"] = "Archived"
-    content["archived"] = True
+    if isinstance(content, Content):
+        content.state = "Archived"
+        content.archived = True
+    else:
+        content["state"] = "Archived"
+        content["archived"] = True
     return content

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,13 +22,13 @@ Authorization: Bearer <token>
 Returns a list of supported content types.
 
 ### `POST /content`
-Create a new content item. The body must include a `type` field with one of the supported values and `metadata` containing at least `created_by`, `created_at` and `timestamps`. Regardless of any provided value, newly created items are stored in the `Draft` state.
+Create a new content item. The body must include a `type` field with one of the supported values as well as `created_by`, `created_at` and `timestamps`. Regardless of any provided value, newly created items are stored in the `Draft` state.
 
 ### `GET /content/<uuid>`
 Retrieve a stored content item.
 
 ### `PUT /content/<uuid>`
-Update a content item. The `type` and entire `metadata` block are immutable via this endpoint.
+Update a content item. The `type` and all metadata fields are immutable via this endpoint.
 
 ### `DELETE /content/<uuid>`
 Archive a content item. Items are not removed from the system.

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -8,16 +8,6 @@ classDiagram
         uuid: str
         title: str
         type: ContentType
-        metadata: Metadata
-        revisions: Revision[]
-        published_revision: str
-        draft_revision: str
-        state: str
-        archived: bool
-        file: str
-        pre_submission: bool
-    }
-    class Metadata {
         created_by: str
         created_at: str
         edited_by: str
@@ -27,12 +17,18 @@ classDiagram
         approved_by: str
         approved_at: str
         timestamps: str
+        revisions: Revision[]
+        published_revision: str
+        draft_revision: str
+        state: str
+        archived: bool
+        file: str
+        pre_submission: bool
     }
     class Revision {
         uuid: str
         last_updated: str
     }
-    Content --> Metadata
     Content --> "1..*" Revision
 ```
 
@@ -41,7 +37,15 @@ classDiagram
 - **uuid** – unique identifier for the content item.
 - **title** – human readable title.
 - **type** – one of the values from `cms.types.ContentType`.
-- **metadata** – object containing audit and workflow metadata. `created_by`, `created_at` and `timestamps` are required when creating new items.
+- **created_by** – user UUID that created the item (required).
+- **created_at** – creation timestamp (required).
+- **edited_by** – UUID of the user currently editing the item.
+- **edited_at** – timestamp of the last edit.
+- **draft_requested_by** – UUID of the user that requested approval.
+- **draft_requested_at** – when approval was requested.
+- **approved_by** – UUID of the approver.
+- **approved_at** – timestamp of approval.
+- **timestamps** – original creation timestamp (required).
 - **revisions** – list of revision objects. Each revision includes a `uuid` and `last_updated` timestamp.
 - **published_revision** – UUID of the currently published revision.
 - **draft_revision** – UUID of the most recent draft revision.

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -47,7 +47,7 @@ def test_post_invalid_content_type(tmp_path):
     assert status == 200
     token = body["token"]
 
-    content = {"title": "Bad", "type": "unknown", "metadata": {}}
+    content = {"title": "Bad", "type": "unknown"}
     status, body = _request(base_url, "POST", "/content", content, token=token)
     server.shutdown()
     thread.join()
@@ -62,7 +62,7 @@ def test_type_immutable_on_update(tmp_path):
     token = body["token"]
 
     users = seed_users()
-    content = sample_content(users)
+    content = sample_content(users).to_dict()
     status, body = _request(base_url, "POST", "/content", content, token=token)
     assert status == 201
 
@@ -83,13 +83,12 @@ def test_metadata_immutable_on_update(tmp_path):
     token = body["token"]
 
     users = seed_users()
-    content = sample_content(users)
+    content = sample_content(users).to_dict()
     status, body = _request(base_url, "POST", "/content", content, token=token)
     assert status == 201
 
     updated = body.copy()
-    updated["metadata"] = updated["metadata"].copy()
-    updated["metadata"]["created_by"] = users["admin"]["uuid"]
+    updated["created_by"] = users["admin"]["uuid"]
     status, body = _request(base_url, "PUT", f"/content/{updated['uuid']}", updated, token=token)
     server.shutdown()
     thread.join()

--- a/tests/test_pdf_upload.py
+++ b/tests/test_pdf_upload.py
@@ -58,17 +58,15 @@ def test_upload_pdf_content(api_server, auth_token, users):
         "title": "PDF Upload",
         "type": ContentType.PDF.value,
         "file": encoded,
-        "metadata": {
-            "created_by": users["editor"]["uuid"],
-            "created_at": "2025-06-09T12:00:00",
-            "edited_by": None,
-            "edited_at": None,
-            "draft_requested_by": None,
-            "draft_requested_at": None,
-            "approved_by": None,
-            "approved_at": None,
-            "timestamps": "2025-06-09T12:00:00",
-        },
+        "created_by": users["editor"]["uuid"],
+        "created_at": "2025-06-09T12:00:00",
+        "edited_by": None,
+        "edited_at": None,
+        "draft_requested_by": None,
+        "draft_requested_at": None,
+        "approved_by": None,
+        "approved_at": None,
+        "timestamps": "2025-06-09T12:00:00",
     }
 
     status, body = _request(api_server, "POST", "/content", content, token=auth_token)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -19,7 +19,7 @@ def users():
 
 @pytest.fixture()
 def content_html(users):
-    return sample_content(users)
+    return sample_content(users).to_dict()
 
 
 @pytest.fixture()
@@ -90,7 +90,7 @@ def test_check_required_metadata_success(api_server, content_html, auth_token):
 
 
 def test_content_created_without_state_starts_in_draft(api_server, users, auth_token):
-    content = sample_content(users)
+    content = sample_content(users).to_dict()
     content.pop("state", None)
     status, body = _request(api_server, "POST", "/content", content, token=auth_token)
     assert status == 201
@@ -109,10 +109,8 @@ def test_export_json_missing_metadata(api_server, users, auth_token):
         "uuid": "12350",
         "title": "Missing Metadata Content",
         "type": "HTML",
-        "metadata": {
-            "created_by": users["editor"]["uuid"],
-            # Missing 'created_at' and 'timestamps'
-        },
+        "created_by": users["editor"]["uuid"],
+        # Missing 'created_at' and 'timestamps'
         "state": "Draft",
         "archived": False,
     }


### PR DESCRIPTION
## Summary
- add `cms.models` with dataclasses for content and revisions
- update workflow logic to handle metadata fields on the content class
- allow API to work with metadata stored at the top level
- adjust sample content factory and tests to new structure
- update documentation for new content schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456ba6b76c83229915347173b76a4c