### PR TITLE
Document generic revision structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Each content item stored by the API contains:
 
 1. A content `type` from `cms.types.ContentType`.
 2. A unique `uuid` identifying the content.
-3. A list of `revisions`, each with its own `uuid` and `last_updated` timestamp.
+3. A list of `revisions`. Each revision entry stores:
+   - a `uuid` identifying that revision,
+   - a `last_updated` timestamp,
+   - and a dictionary of type-specific `attributes`.
 4. References to the `published_revision` and `draft_revision` by UUID.
 
 The helper `cms.data.sample_content` returns an example object with this
@@ -25,7 +28,8 @@ created. A full breakdown of all fields can be found in
 
 ## Supported Content Types
 
-The API works with four distinct content types defined in `cms.types.ContentType`:
+The API works with four distinct content types defined in `cms.types.ContentType`.
+All content types share the same metadata and revision structure:
 
 1. `html`
 2. `pdf`

--- a/cms/data.py
+++ b/cms/data.py
@@ -14,7 +14,11 @@ def sample_content(users):
     """Create example HTML content using the provided users."""
     timestamp = "2025-06-08T12:00:00"
     revision_uuid = "rev-12345"
-    revision = Revision(uuid=revision_uuid, last_updated=timestamp)
+    revision = Revision(
+        uuid=revision_uuid,
+        last_updated=timestamp,
+        attributes={"title": "Sample HTML Content"},
+    )
     return HTMLContent(
         uuid="12345",
         title="Sample HTML Content",

--- a/cms/models.py
+++ b/cms/models.py
@@ -6,6 +6,7 @@ from .types import ContentType
 class Revision:
     uuid: str
     last_updated: str
+    attributes: dict = field(default_factory=dict)
 
 @dataclass
 class Content:

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -28,6 +28,7 @@ classDiagram
     class Revision {
         uuid: str
         last_updated: str
+        attributes: dict
     }
     Content --> "1..*" Revision
 ```
@@ -46,7 +47,7 @@ classDiagram
 - **approved_by** – UUID of the approver.
 - **approved_at** – timestamp of approval.
 - **timestamps** – original creation timestamp (required).
-- **revisions** – list of revision objects. Each revision includes a `uuid` and `last_updated` timestamp.
+- **revisions** – list of revision objects. Every revision entry contains a `uuid`, a `last_updated` timestamp, and a dictionary of type-specific `attributes` representing the content at that revision.
 - **published_revision** – UUID of the currently published revision.
 - **draft_revision** – UUID of the most recent draft revision.
 - **state** – workflow state such as `Draft` or `AwaitingApproval`. Newly created items always start in the `Draft` state.


### PR DESCRIPTION
## Summary
- include `attributes` field in `Revision`
- populate sample content with attributes
- document revision attributes in README and DataStructure docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845717731a4832291bece6529b08294