### PR TITLE
Update revision fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Each content item stored by the API contains:
    - a `uuid` identifying that revision,
    - a `last_updated` timestamp,
    - and a dictionary of type-specific `attributes`.
-4. References to the `published_revision` and `draft_revision` by UUID.
+4. References to the `published_revision` and `review_revision` by UUID. These
+   fields are ``null`` when content is first created.
 
 The helper `cms.data.sample_content` returns an example object with this
-structure and the API will populate missing revision fields when new content is
-created. A full breakdown of all fields can be found in
+structure. When creating content, the API leaves the revision references
+unset so new items begin in the ``Draft`` state. A full breakdown of all
+fields can be found in
 [docs/DataStructure.md](docs/DataStructure.md).
 
 ## Supported Content Types

--- a/cms/api.py
+++ b/cms/api.py
@@ -31,15 +31,11 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             rev_uuid = str(uuid.uuid4())
             ts = item.get("timestamps") or item.get("metadata", {}).get("timestamps")
             item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts}]
-            item.setdefault("published_revision", rev_uuid)
-            item.setdefault("draft_revision", rev_uuid)
         else:
             for rev in item["revisions"]:
                 rev.setdefault(
                     "last_updated", item.get("timestamps") or item.get("metadata", {}).get("timestamps")
                 )
-            item.setdefault("published_revision", item["revisions"][0]["uuid"])
-            item.setdefault("draft_revision", item["revisions"][-1]["uuid"])
 
     @staticmethod
     def _add_revision(item):
@@ -58,7 +54,7 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             attrs["file"] = item["file"]
         item.setdefault("revisions", [])
         item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
-        item["draft_revision"] = rev_uuid
+        item["review_revision"] = rev_uuid
 
     def _authenticate(self):
         auth = self.headers.get("Authorization", "")

--- a/cms/data.py
+++ b/cms/data.py
@@ -26,6 +26,4 @@ def sample_content(users):
         created_at=timestamp,
         timestamps=timestamp,
         revisions=[revision],
-        published_revision=revision_uuid,
-        draft_revision=revision_uuid,
     )

--- a/cms/models.py
+++ b/cms/models.py
@@ -24,7 +24,7 @@ class Content:
     timestamps: str = ""
     revisions: List[Revision] = field(default_factory=list)
     published_revision: Optional[str] = None
-    draft_revision: Optional[str] = None
+    review_revision: Optional[str] = None
     state: str = "Draft"
     archived: bool = False
     file: Optional[str] = None

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -19,7 +19,7 @@ classDiagram
         timestamps: str
         revisions: Revision[]
         published_revision: str
-        draft_revision: str
+        review_revision: str
         state: str
         archived: bool
         file: str
@@ -48,8 +48,9 @@ classDiagram
 - **approved_at** – timestamp of approval.
 - **timestamps** – original creation timestamp (required).
 - **revisions** – list of revision objects. Every revision entry contains a `uuid`, a `last_updated` timestamp, and a dictionary of type-specific `attributes` representing the content at that revision.
-- **published_revision** – UUID of the currently published revision.
-- **draft_revision** – UUID of the most recent draft revision.
+ - **published_revision** – UUID of the currently published revision.
+ - **review_revision** – UUID of the most recent review revision. Both fields
+   are ``null`` when content is first created.
 - **state** – workflow state such as `Draft` or `AwaitingApproval`. Newly created items always start in the `Draft` state.
 - **archived** – set to `true` if the item is no longer active.
 - **file** – base64 encoded file contents (PDF only).

--- a/tests/test_pdf_upload.py
+++ b/tests/test_pdf_upload.py
@@ -76,3 +76,5 @@ def test_upload_pdf_content(api_server, auth_token, users):
     assert "uuid" in body and body["uuid"]
     assert body["state"] == "Draft"
     assert body["pre_submission"] is True
+    assert body.get("published_revision") is None
+    assert body.get("review_revision") is None

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -53,11 +53,15 @@ def test_revision_history(api_server, users, auth_token):
     status, body = _request(api_server, "POST", "/content", content, token=auth_token)
     assert status == 201
     assert len(body["revisions"]) == 1
+    assert body.get("review_revision") is None
+    assert body.get("published_revision") is None
 
     for i in range(3):
         updated = body.copy()
         updated["title"] = f"Update {i}"
         status, body = _request(api_server, "PUT", f"/content/{updated['uuid']}", updated, token=auth_token)
         assert status == 200
+
+    assert body["review_revision"] == body["revisions"][-1]["uuid"]
 
     assert len(body["revisions"]) == 4

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -95,6 +95,8 @@ def test_content_created_without_state_starts_in_draft(api_server, users, auth_t
     status, body = _request(api_server, "POST", "/content", content, token=auth_token)
     assert status == 201
     assert body["state"] == "Draft"
+    assert body.get("published_revision") is None
+    assert body.get("review_revision") is None
 
 
 def test_content_state_overridden_to_draft(api_server, content_html, auth_token):
@@ -102,6 +104,8 @@ def test_content_state_overridden_to_draft(api_server, content_html, auth_token)
     status, body = _request(api_server, "POST", "/content", content_html, token=auth_token)
     assert status == 201
     assert body["state"] == "Draft"
+    assert body.get("published_revision") is None
+    assert body.get("review_revision") is None
 
 
 def test_export_json_missing_metadata(api_server, users, auth_token):


### PR DESCRIPTION
## Summary
- introduce `review_revision` instead of `draft_revision`
- leave revision pointers unset for new content
- update documentation for revision fields
- verify via tests that the revision fields are `None` when content is created

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457d62425083228fb0e1855e8aa819