### PR TITLE
Enforce flat categories

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -41,6 +41,15 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
         return categories
 
     @staticmethod
+    def _valid_flat_category_list(categories):
+        """Return True if ``categories`` is a flat list of strings."""
+        if categories is None:
+            return True
+        if not isinstance(categories, list):
+            return False
+        return all(isinstance(cat, str) for cat in categories)
+
+    @staticmethod
     def _ensure_revision_structure(item):
         """Populate revision fields if missing."""
         if "revisions" not in item or not item["revisions"]:
@@ -261,6 +270,12 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             self._send_json({"error": "invalid type"}, status=400)
             return
 
+        if not self._valid_flat_category_list(item.get("categories")):
+            self._send_json(
+                {"error": "categories must be a flat list of strings"}, status=400
+            )
+            return
+
         # validate required metadata on creation
         try:
             check_required_metadata(item)
@@ -322,6 +337,12 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             new_type = incoming.get("type", existing.get("type"))
             if new_type != existing.get("type"):
                 self._send_json({"error": "type cannot be changed"}, status=400)
+                return
+
+            if not self._valid_flat_category_list(incoming.get("categories")):
+                self._send_json(
+                    {"error": "categories must be a flat list of strings"}, status=400
+                )
                 return
 
             # metadata fields are immutable via this endpoint

--- a/docs/API.md
+++ b/docs/API.md
@@ -56,6 +56,7 @@ Return a simple authentication token for the supplied username.
 
 ### `POST /categories`
 Create a category. The body accepts `name` and optional `display_priority`.
+Categories are flat and have no parent/child hierarchy.
 
 ### `GET /categories`
 List all active categories sorted by display priority (1 is highest) then alphabetically.

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -76,3 +76,5 @@ Category objects returned by the API contain:
 - **name** – display name for the category.
 - **display_priority** – integer used to order categories.
 - **archived** – set to `true` when the category has been removed from active use.
+
+Categories are **flat**; the API does not currently support parent/child relationships.


### PR DESCRIPTION
## Summary
- validate that categories lists are flat when creating or updating content
- mention flat categories in API and data structure docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845886299dc83229a3df95455822d9d