### PR TITLE
Implement content-by-type listing endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,10 @@ Authorization: Bearer <token>
 ### `GET /content-types`
 Returns a list of supported content types.
 
+### `GET /content-types/<type>`
+List all published content items for the given type. The `<type>` parameter must
+match one of the values returned by `GET /content-types`.
+
 ### `POST /content`
 Create a new content item. The body must include a `type` field with one of the supported values as well as `created_by`, `created_at` and `timestamps`. Regardless of any provided value, newly created items are stored in the `Draft` state.
 

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -94,3 +94,47 @@ def test_metadata_immutable_on_update(tmp_path):
     thread.join()
     assert status == 400
     assert body["error"] == "metadata immutable"
+
+
+def _publish_item(base_url, token, users, uuid):
+    data = {"timestamp": "2025-06-09T10:00:00", "user_uuid": users["editor"]["uuid"]}
+    status, _ = _request(base_url, "POST", f"/content/{uuid}/request-approval", data, token=token)
+    assert status == 200
+    data = {"timestamp": "2025-06-09T11:00:00", "user_uuid": users["admin"]["uuid"]}
+    status, _ = _request(base_url, "POST", f"/content/{uuid}/approve", data, token=token)
+    assert status == 200
+
+
+def test_list_content_by_type(tmp_path):
+    server, thread = start_test_server()
+    base_url = f"http://localhost:{server.server_port}"
+    users = seed_users()
+
+    status, body = _request(base_url, "POST", "/test-token", {"username": "t"})
+    assert status == 200
+    token = body["token"]
+
+    # create a category to demonstrate categories are ignored
+    status, body = _request(base_url, "POST", "/categories", {"name": "C"})
+    cat_uuid = body["uuid"]
+
+    c1 = sample_content(users).to_dict()
+    c1["uuid"] = "html1"
+    status, _ = _request(base_url, "POST", "/content", c1, token=token)
+    assert status == 201
+    _publish_item(base_url, token, users, c1["uuid"])
+
+    c2 = sample_content(users).to_dict()
+    c2["uuid"] = "html2"
+    c2["categories"] = [cat_uuid]
+    status, _ = _request(base_url, "POST", "/content", c2, token=token)
+    assert status == 201
+    _publish_item(base_url, token, users, c2["uuid"])
+
+    status, body = _request(base_url, "GET", "/content-types/html")
+    server.shutdown()
+    thread.join()
+
+    returned = {item["uuid"] for item in body}
+    assert status == 200
+    assert returned == {"html1", "html2"}


### PR DESCRIPTION
## Summary
- add endpoint `/content-types/<type>` to list published content by type
- reset in-memory data between test server runs
- document the new endpoint
- test listing content by type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845898bb3508322b64a4265b3780ad0