### PR TITLE
Add sample content seeder

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -1,5 +1,11 @@
 from .types import ContentType
-from .models import HTMLContent, Revision
+from .models import (
+    HTMLContent,
+    PDFContent,
+    OfficeAddressContent,
+    EventScheduleContent,
+    Revision,
+)
 
 
 def seed_users():
@@ -28,3 +34,34 @@ def sample_content(users):
         revisions=[revision],
         categories=[],
     )
+
+
+def seed_example_contents(users):
+    """Return example content objects for each supported type."""
+    timestamp = "2025-06-08T12:00:00"
+    contents = []
+    for ct in ContentType:
+        for i in range(2):
+            rev = Revision(
+                uuid=f"{ct.value}-{i}-rev",
+                last_updated=timestamp,
+                attributes={"title": f"Example {ct.value} {i}"},
+            )
+            base_kwargs = dict(
+                uuid=f"{ct.value}-{i}",
+                title=f"Example {ct.value} {i}",
+                created_by=users["editor"]["uuid"],
+                created_at=timestamp,
+                timestamps=timestamp,
+                revisions=[rev],
+                categories=[],
+            )
+            if ct is ContentType.HTML:
+                contents.append(HTMLContent(**base_kwargs))
+            elif ct is ContentType.PDF:
+                contents.append(PDFContent(**base_kwargs))
+            elif ct is ContentType.OFFICE_ADDRESS:
+                contents.append(OfficeAddressContent(**base_kwargs))
+            elif ct is ContentType.EVENT_SCHEDULE:
+                contents.append(EventScheduleContent(**base_kwargs))
+    return contents

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cms.data import seed_users, seed_example_contents
+from cms.types import ContentType
+
+
+def test_seed_example_contents():
+    users = seed_users()
+    contents = seed_example_contents(users)
+    # there should be at least two items for each type
+    type_counts = {ct: 0 for ct in ContentType}
+    uuids = set()
+    for item in contents:
+        assert item.type in ContentType
+        type_counts[item.type] += 1
+        uuids.add(item.uuid)
+        # ensure dataclass to_dict works
+        assert item.to_dict()["type"] == item.type.value
+    assert all(count >= 2 for count in type_counts.values())
+    assert len(uuids) == len(contents)


### PR DESCRIPTION
## Summary
- extend data factories to generate sample content for each supported type
- test the new seeder works via pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458c5d938883229b7541c034ed9030