### PR TITLE
Add PyQt test client

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,16 @@ content = request_approval(content, users["editor"], "2025-06-09T10:15:00")
 ```
 
 See the tests in the `tests` directory for more examples.
+
+## PyQt Test Client
+
+The repository includes a small PyQt5 GUI (`qt_client.py`) that demonstrates the
+HTTP API. Running the script starts the test server, seeds it with example data
+from `cms.data`, and lets you browse content items. Each user action shows the
+underlying API request and JSON response in a log panel.
+
+Run the client with:
+
+```bash
+python qt_client.py
+```

--- a/cms/client_api.py
+++ b/cms/client_api.py
@@ -1,0 +1,69 @@
+import json
+from typing import Optional
+from urllib import request, parse
+
+
+class ApiClient:
+    """Simple HTTP client for the CMS test server."""
+
+    def __init__(self, base_url: str, token: Optional[str] = None):
+        self.base_url = base_url.rstrip("/")
+        self.token: Optional[str] = token
+
+    def _make_request(self, method: str, path: str, data=None, token: Optional[str] = None):
+        url = self.base_url + path
+        headers = {}
+        current_token = token or self.token
+        if current_token:
+            headers["Authorization"] = f"Bearer {current_token}"
+        body = None
+        if data is not None:
+            body = json.dumps(data).encode()
+            headers["Content-Type"] = "application/json"
+        req = request.Request(url, data=body, headers=headers, method=method)
+        with request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+
+    def get(self, path: str, token: Optional[str] = None):
+        return self._make_request("GET", path, token=token)
+
+    def post(self, path: str, data, token: Optional[str] = None):
+        return self._make_request("POST", path, data=data, token=token)
+
+    def put(self, path: str, data, token: Optional[str] = None):
+        return self._make_request("PUT", path, data=data, token=token)
+
+    def delete(self, path: str, token: Optional[str] = None):
+        return self._make_request("DELETE", path, token=token)
+
+    # Convenience helpers
+    def create_token(self, username: str) -> str:
+        resp = self.post("/test-token", {"username": username})
+        self.token = resp["token"]
+        return self.token
+
+    def get_content_types(self):
+        return self.get("/content-types")
+
+    def list_content_by_type(self, content_type: str):
+        quoted = parse.quote(content_type)
+        return self.get(f"/content-types/{quoted}")
+
+    def get_content(self, uuid: str):
+        return self.get(f"/content/{uuid}", token=self.token)
+
+    def create_content(self, item: dict):
+        return self.post("/content", item, token=self.token)
+
+
+# Seeder --------------------------------------------------------------
+from .data import seed_users, seed_example_contents
+
+def seed_server(api: ApiClient):
+    """Populate the running API server using the built-in seed data."""
+    users = seed_users()
+    contents = seed_example_contents(users)
+    api.create_token("editor")
+    for item in contents:
+        api.create_content(item.to_dict())
+    return users

--- a/qt_client.py
+++ b/qt_client.py
@@ -1,0 +1,97 @@
+import sys
+import json
+from PyQt5.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QListWidget,
+    QTextEdit,
+    QLabel,
+)
+from PyQt5.QtCore import Qt
+
+from cms.api import start_test_server
+from cms.client_api import ApiClient, seed_server
+
+
+class CmsWindow(QMainWindow):
+    def __init__(self, api: ApiClient):
+        super().__init__()
+        self.api = api
+        self.setWindowTitle("CMS PyQt Test Client")
+        self._setup_ui()
+        self._load_content_types()
+
+    def _setup_ui(self):
+        central = QWidget()
+        self.setCentralWidget(central)
+
+        main_layout = QHBoxLayout(central)
+
+        self.type_list = QListWidget()
+        self.item_list = QListWidget()
+        self.output = QTextEdit()
+        self.output.setReadOnly(True)
+
+        left_layout = QVBoxLayout()
+        left_layout.addWidget(QLabel("Content Types"))
+        left_layout.addWidget(self.type_list)
+
+        right_layout = QVBoxLayout()
+        right_layout.addWidget(QLabel("Items"))
+        right_layout.addWidget(self.item_list)
+        right_layout.addWidget(QLabel("API Responses"))
+        right_layout.addWidget(self.output)
+
+        main_layout.addLayout(left_layout)
+        main_layout.addLayout(right_layout)
+
+        self.type_list.itemClicked.connect(self._load_items)
+        self.item_list.itemClicked.connect(self._show_item)
+
+    def _append_response(self, request_desc: str, data):
+        self.output.append(request_desc)
+        self.output.append(json.dumps(data, indent=2))
+        self.output.append("")
+
+    def _load_content_types(self):
+        types = self.api.get_content_types()
+        self._append_response("GET /content-types", types)
+        self.type_list.clear()
+        for ct in types:
+            self.type_list.addItem(ct)
+
+    def _load_items(self, item):
+        ct = item.text()
+        items = self.api.list_content_by_type(ct)
+        self._append_response(f"GET /content-types/{ct}", items)
+        self.item_list.clear()
+        for obj in items:
+            lw_item = f"{obj['uuid']} - {obj.get('title', '')}"
+            self.item_list.addItem(lw_item)
+            self.item_list.item(self.item_list.count() - 1).setData(Qt.UserRole, obj['uuid'])
+
+    def _show_item(self, item):
+        uuid = item.data(Qt.UserRole)
+        data = self.api.get_content(uuid)
+        self._append_response(f"GET /content/{uuid}", data)
+
+
+def main():
+    server, _ = start_test_server(0)
+    base_url = f"http://localhost:{server.server_port}"
+    api = ApiClient(base_url)
+    seed_server(api)
+
+    app = QApplication(sys.argv)
+    window = CmsWindow(api)
+    window.resize(800, 600)
+    window.show()
+    app.exec_()
+    server.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide API helper `cms/client_api.py` with a seeding utility
- add `qt_client.py` PyQt5 demo application using the helper and seed data
- document running the GUI in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458d8b52d483228ecd7a43d559778d