### PR TITLE
Fix content-type listing for Qt client

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from .types import ContentType
 from .workflow import (
@@ -114,7 +114,9 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             self._send_json(sorted(self.valid_types))
             return
         if parsed.path.startswith("/content-types/"):
-            item_type = parsed.path.split("/")[-1]
+            # decode any percent-encoding to allow client requests that
+            # properly escape spaces in content type values
+            item_type = unquote(parsed.path.split("/")[-1])
             if item_type not in self.valid_types:
                 self._send_json({"error": "invalid type"}, status=400)
                 return

--- a/cms/client_api.py
+++ b/cms/client_api.py
@@ -46,9 +46,11 @@ class ApiClient:
         return self.get("/content-types")
 
     def list_content_by_type(self, content_type: str):
-        # Server endpoints expect the raw content type value without
-        # percent-encoding, even if it contains spaces.
-        return self.get(f"/content-types/{content_type}")
+        # Content types may contain spaces (e.g. "event schedule").
+        # ``urllib.request`` does not allow spaces in the request path, so we
+        # percent-encode the value.  The server will decode it again.
+        encoded = parse.quote(content_type, safe="")
+        return self.get(f"/content-types/{encoded}")
 
     def get_content(self, uuid: str):
         return self.get(f"/content/{uuid}", token=self.token)


### PR DESCRIPTION
## Summary
- URL-encode content types in `ApiClient.list_content_by_type`
- decode percent-encoded content type values on the server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684593bf04dc83229c5cf69b2bcf828e