### PR TITLE
Generate UUIDs for seed data

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -1,4 +1,6 @@
 from .types import ContentType
+import uuid
+
 from .models import (
     HTMLContent,
     PDFContent,
@@ -9,24 +11,24 @@ from .models import (
 
 
 def seed_users():
-    """Return a dictionary of example users."""
+    """Return a dictionary of example users with generated UUIDs."""
     return {
-        "editor": {"uuid": "1111-1111-1111-1111", "role": "editor"},
-        "admin": {"uuid": "2222-2222-2222-2222", "role": "admin"},
+        "editor": {"uuid": str(uuid.uuid4()), "role": "editor"},
+        "admin": {"uuid": str(uuid.uuid4()), "role": "admin"},
     }
 
 
 def sample_content(users):
     """Create example HTML content using the provided users."""
     timestamp = "2025-06-08T12:00:00"
-    revision_uuid = "rev-12345"
+    revision_uuid = str(uuid.uuid4())
     revision = Revision(
         uuid=revision_uuid,
         last_updated=timestamp,
         attributes={"title": "Sample HTML Content"},
     )
     return HTMLContent(
-        uuid="12345",
+        uuid=str(uuid.uuid4()),
         title="Sample HTML Content",
         created_by=users["editor"]["uuid"],
         created_at=timestamp,
@@ -41,15 +43,15 @@ def seed_example_contents(users):
     timestamp = "2025-06-08T12:00:00"
     contents = []
     for ct in ContentType:
-        for i in range(2):
+        for _ in range(2):
             rev = Revision(
-                uuid=f"{ct.value}-{i}-rev",
+                uuid=str(uuid.uuid4()),
                 last_updated=timestamp,
-                attributes={"title": f"Example {ct.value} {i}"},
+                attributes={"title": f"Example {ct.value}"},
             )
             base_kwargs = dict(
-                uuid=f"{ct.value}-{i}",
-                title=f"Example {ct.value} {i}",
+                uuid=str(uuid.uuid4()),
+                title=f"Example {ct.value}",
                 created_by=users["editor"]["uuid"],
                 created_at=timestamp,
                 timestamps=timestamp,

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -3,6 +3,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+import uuid
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -52,16 +53,19 @@ def test_category_sort_order():
     server, thread = start_test_server()
     base_url = f"http://localhost:{server.server_port}"
 
-    _request(base_url, "POST", "/categories", {"uuid": "1", "name": "Bananas"})
-    _request(base_url, "POST", "/categories", {"uuid": "2", "name": "Apples"})
-    _request(base_url, "POST", "/categories", {"uuid": "3", "name": "Zebras", "display_priority": 1})
+    uuid1 = str(uuid.uuid4())
+    uuid2 = str(uuid.uuid4())
+    uuid3 = str(uuid.uuid4())
+    _request(base_url, "POST", "/categories", {"uuid": uuid1, "name": "Bananas"})
+    _request(base_url, "POST", "/categories", {"uuid": uuid2, "name": "Apples"})
+    _request(base_url, "POST", "/categories", {"uuid": uuid3, "name": "Zebras", "display_priority": 1})
 
     status, body = _request(base_url, "GET", "/categories")
     server.shutdown()
     thread.join()
 
     uuids = [c["uuid"] for c in body]
-    assert uuids == ["3", "2", "1"]
+    assert uuids == [uuid3, uuid2, uuid1]
 
 
 def test_content_with_categories():

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import uuid
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -119,13 +120,15 @@ def test_list_content_by_type(tmp_path):
     cat_uuid = body["uuid"]
 
     c1 = sample_content(users).to_dict()
-    c1["uuid"] = "html1"
+    uuid1 = str(uuid.uuid4())
+    c1["uuid"] = uuid1
     status, _ = _request(base_url, "POST", "/content", c1, token=token)
     assert status == 201
     _publish_item(base_url, token, users, c1["uuid"])
 
     c2 = sample_content(users).to_dict()
-    c2["uuid"] = "html2"
+    uuid2 = str(uuid.uuid4())
+    c2["uuid"] = uuid2
     c2["categories"] = [cat_uuid]
     status, _ = _request(base_url, "POST", "/content", c2, token=token)
     assert status == 201
@@ -137,7 +140,7 @@ def test_list_content_by_type(tmp_path):
 
     returned = {item["uuid"] for item in body}
     assert status == 200
-    assert returned == {"html1", "html2"}
+    assert returned == {uuid1, uuid2}
 
 
 def test_authenticated_list_includes_drafts(tmp_path):
@@ -151,7 +154,8 @@ def test_authenticated_list_includes_drafts(tmp_path):
 
     # create item but leave in Draft state
     content = sample_content(users).to_dict()
-    content["uuid"] = "draft-html"
+    draft_uuid = str(uuid.uuid4())
+    content["uuid"] = draft_uuid
     status, _ = _request(base_url, "POST", "/content", content, token=token)
     assert status == 201
 
@@ -162,4 +166,4 @@ def test_authenticated_list_includes_drafts(tmp_path):
 
     returned = {item["uuid"] for item in body}
     assert status == 200
-    assert "draft-html" in returned
+    assert draft_uuid in returned

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -4,6 +4,7 @@ import os
 import sys
 import urllib.request
 import urllib.error
+import uuid
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -31,7 +32,7 @@ def _sample_content(content_type, users, idx):
     """Return a content payload with type-specific attributes."""
     ts = "2025-06-08T12:00:00"
     content = {
-        "uuid": f"uuid-{idx}",
+        "uuid": str(uuid.uuid4()),
         "title": f"{content_type.title()} Item {idx}",
         "type": content_type,
         "created_by": users["editor"]["uuid"],

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -3,6 +3,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+import uuid
 
 import pytest
 
@@ -110,7 +111,7 @@ def test_content_state_overridden_to_draft(api_server, content_html, auth_token)
 
 def test_export_json_missing_metadata(api_server, users, auth_token):
     invalid_content = {
-        "uuid": "12350",
+        "uuid": str(uuid.uuid4()),
         "title": "Missing Metadata Content",
         "type": "HTML",
         "created_by": users["editor"]["uuid"],


### PR DESCRIPTION
## Summary
- ensure seed functions create real UUIDs
- allow tests to work with generated identifiers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a7f8d71c8322923c19a726545975