### PR TITLE
Remove archived flag in favor of Archived status

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -126,7 +126,7 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
                 for i in self.store.values()
                 if i.get("type") == item_type
                 and (authenticated or i.get("state") == "Published")
-                and not i.get("archived")
+                and i.get("state") != "Archived"
             ]
             self._send_json(items)
             return
@@ -146,7 +146,7 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
                 item
                 for item in self.store.values()
                 if (authenticated or item.get("state") == "Published")
-                and not item.get("archived")
+                and item.get("state") != "Archived"
             ]
             self._send_json(items)
             return

--- a/cms/models.py
+++ b/cms/models.py
@@ -34,7 +34,6 @@ class Content:
     published_revision: Optional[str] = None
     review_revision: Optional[str] = None
     state: str = "Draft"
-    archived: bool = False
     file: Optional[str] = None
     pre_submission: Optional[bool] = None
     categories: List[str] = field(default_factory=list)

--- a/cms/workflow.py
+++ b/cms/workflow.py
@@ -86,10 +86,11 @@ def archive_content(content):
     """Mark a content item as archived."""
     if isinstance(content, Content):
         content.state = "Archived"
-        content.archived = True
+        if hasattr(content, "archived"):
+            delattr(content, "archived")
     else:
         content["state"] = "Archived"
-        content["archived"] = True
+        content.pop("archived", None)
     return content
 
 

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -21,7 +21,6 @@ classDiagram
         published_revision: str
         review_revision: str
         state: str
-        archived: bool
         file: str
         pre_submission: bool
         categories: List[str]
@@ -52,8 +51,7 @@ classDiagram
  - **published_revision** – UUID of the currently published revision.
  - **review_revision** – UUID of the most recent review revision. Both fields
    are ``null`` when content is first created.
-- **state** – workflow state such as `Draft` or `AwaitingApproval`. Newly created items always start in the `Draft` state.
-- **archived** – set to `true` if the item is no longer active.
+ - **state** – workflow state such as `Draft`, `AwaitingApproval`, `Published`, or `Archived`. Newly created items always start in the `Draft` state.
 - **file** – base64 encoded file contents (PDF only).
 - **pre_submission** – boolean that indicates a newly created PDF has not yet been submitted for approval.
 - **categories** – list of category UUIDs the content belongs to.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -117,7 +117,6 @@ def test_export_json_missing_metadata(api_server, users, auth_token):
         "created_by": users["editor"]["uuid"],
         # Missing 'created_at' and 'timestamps'
         "state": "Draft",
-        "archived": False,
     }
 
     status, body = _request(api_server, "POST", "/check-metadata", invalid_content, token=auth_token)
@@ -171,10 +170,11 @@ def test_crud_flow(api_server, content_html, auth_token):
     # ARCHIVE
     status, body = _request(api_server, "DELETE", f"/content/{updated['uuid']}", token=auth_token)
     assert status == 200
-    assert body["archived"] is True
     assert body["state"] == "Archived"
+    assert "archived" not in body
 
     # Confirm archived item is still retrievable
     status, body = _request(api_server, "GET", f"/content/{updated['uuid']}", token=auth_token)
     assert status == 200
-    assert body["archived"] is True
+    assert body["state"] == "Archived"
+    assert "archived" not in body


### PR DESCRIPTION
## Summary
- remove `archived` field from `Content`
- drop archived boolean handling in the workflow and API
- document Archived state
- adjust workflow tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f9c66274832298212b9d4f2231d6