### PR TITLE
Refactor content workflow structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Each content item stored by the API contains:
    fields are ``null`` when content is first created.
 
 The helper `cms.data.sample_content` returns an example object with this
-structure. When creating content, the API leaves the revision references
-unset so new items begin in the ``Draft`` state. A full breakdown of all
+structure. A full breakdown of all
 fields can be found in
 [docs/DataStructure.md](docs/DataStructure.md).
 

--- a/cms/data.py
+++ b/cms/data.py
@@ -29,12 +29,12 @@ def sample_content(users):
     )
     return HTMLContent(
         uuid=str(uuid.uuid4()),
-        title="Sample HTML Content",
         created_by=users["editor"]["uuid"],
         created_at=timestamp,
         timestamps=timestamp,
         revisions=[revision],
         categories=[],
+        review_content={"title": "Sample HTML Content"},
     )
 
 
@@ -51,12 +51,12 @@ def seed_example_contents(users):
             )
             base_kwargs = dict(
                 uuid=str(uuid.uuid4()),
-                title=f"Example {ct.value}",
                 created_by=users["editor"]["uuid"],
                 created_at=timestamp,
                 timestamps=timestamp,
                 revisions=[rev],
                 categories=[],
+                review_content={"title": f"Example {ct.value}"},
             )
             if ct is ContentType.HTML:
                 contents.append(HTMLContent(**base_kwargs))

--- a/cms/models.py
+++ b/cms/models.py
@@ -19,7 +19,6 @@ class Category:
 @dataclass
 class Content:
     uuid: str
-    title: str
     type: ContentType = field(init=False)
     created_by: str
     created_at: str
@@ -33,10 +32,12 @@ class Content:
     revisions: List[Revision] = field(default_factory=list)
     published_revision: Optional[str] = None
     review_revision: Optional[str] = None
-    state: str = "Draft"
     file: Optional[str] = None
     pre_submission: Optional[bool] = None
     categories: List[str] = field(default_factory=list)
+    published_content: dict = field(default_factory=dict)
+    review_content: dict = field(default_factory=dict)
+    archived: bool = False
 
     def to_dict(self):
         data = asdict(self)

--- a/cms/workflow.py
+++ b/cms/workflow.py
@@ -22,7 +22,6 @@ def request_approval(content, user, timestamp):
     if isinstance(content, Content):
         content.draft_requested_by = user["uuid"]
         content.draft_requested_at = timestamp
-        content.state = "AwaitingApproval"
     else:
         if "draft_requested_by" in content or "metadata" not in content:
             content["draft_requested_by"] = user["uuid"]
@@ -31,7 +30,6 @@ def request_approval(content, user, timestamp):
             content.setdefault("metadata", {})
             content["metadata"]["draft_requested_by"] = user["uuid"]
             content["metadata"]["draft_requested_at"] = timestamp
-        content["state"] = "AwaitingApproval"
     return content
 
 
@@ -39,8 +37,19 @@ def pending_approvals(contents):
     """Return items that are awaiting admin approval."""
     result = []
     for item in contents:
-        state = item.state if isinstance(item, Content) else item.get("state")
-        if state == "AwaitingApproval":
+        if isinstance(item, Content):
+            awaiting = (
+                item.draft_requested_by is not None
+                and item.approved_at is None
+                and not item.archived
+            )
+        else:
+            awaiting = (
+                item.get("draft_requested_by") is not None
+                and item.get("approved_at") is None
+                and not item.get("archived")
+            )
+        if awaiting:
             result.append(item)
     return result
 
@@ -53,24 +62,15 @@ def start_draft(content, user, timestamp):
     """
     if isinstance(content, Content):
         current_editor = content.edited_by
-        if (
-            content.state == "Draft"
-            and current_editor is not None
-            and current_editor != user["uuid"]
-        ):
+        if current_editor is not None and current_editor != user["uuid"]:
             raise PermissionError(f"User {current_editor} has it in draft status")
         content.edited_by = user["uuid"]
         content.edited_at = timestamp
-        content.state = "Draft"
     else:
         current_editor = content.get("edited_by")
         if current_editor is None and "metadata" in content:
             current_editor = content["metadata"].get("edited_by")
-        if (
-            content.get("state") == "Draft"
-            and current_editor is not None
-            and current_editor != user["uuid"]
-        ):
+        if current_editor is not None and current_editor != user["uuid"]:
             raise PermissionError(f"User {current_editor} has it in draft status")
         if "edited_by" in content or "metadata" not in content:
             content["edited_by"] = user["uuid"]
@@ -78,19 +78,15 @@ def start_draft(content, user, timestamp):
         else:
             content["metadata"]["edited_by"] = user["uuid"]
             content["metadata"]["edited_at"] = timestamp
-        content["state"] = "Draft"
     return content
 
 
 def archive_content(content):
     """Mark a content item as archived."""
     if isinstance(content, Content):
-        content.state = "Archived"
-        if hasattr(content, "archived"):
-            delattr(content, "archived")
+        content.archived = True
     else:
-        content["state"] = "Archived"
-        content.pop("archived", None)
+        content["archived"] = True
     return content
 
 
@@ -104,7 +100,9 @@ def approve_content(content, user, timestamp):
         elif content.revisions:
             content.published_revision = content.revisions[-1].uuid
         content.pre_submission = False
-        content.state = "Published"
+        if content.review_content:
+            content.published_content = content.review_content
+            content.review_content = {}
     else:
         if "approved_by" in content or "metadata" not in content:
             content["approved_by"] = user["uuid"]
@@ -118,5 +116,7 @@ def approve_content(content, user, timestamp):
         elif content.get("revisions"):
             content["published_revision"] = content["revisions"][-1]["uuid"]
         content["pre_submission"] = False
-        content["state"] = "Published"
+        if content.get("review_content"):
+            content["published_content"] = content.get("review_content")
+            content["review_content"] = {}
     return content

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,7 +28,7 @@ are included as well. The `<type>` parameter must match one of the values
 returned by `GET /content-types`.
 
 ### `POST /content`
-Create a new content item. The body must include a `type` field with one of the supported values as well as `created_by`, `created_at` and `timestamps`. Regardless of any provided value, newly created items are stored in the `Draft` state.
+Create a new content item. The body must include a `type` field with one of the supported values as well as `created_by`, `created_at` and `timestamps`.
 
 ### `GET /content/<uuid>`
 Retrieve a stored content item.

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -6,7 +6,6 @@ This document describes the JSON schema used for content items stored by the CMS
 classDiagram
     class Content {
         uuid: str
-        title: str
         type: ContentType
         created_by: str
         created_at: str
@@ -20,7 +19,9 @@ classDiagram
         revisions: Revision[]
         published_revision: str
         review_revision: str
-        state: str
+        published_content: dict
+        review_content: dict
+        archived: bool
         file: str
         pre_submission: bool
         categories: List[str]
@@ -36,7 +37,6 @@ classDiagram
 ## Fields
 
 - **uuid** – unique identifier for the content item.
-- **title** – human readable title.
 - **type** – one of the values from `cms.types.ContentType`.
 - **created_by** – user UUID that created the item (required).
 - **created_at** – creation timestamp (required).
@@ -51,18 +51,12 @@ classDiagram
  - **published_revision** – UUID of the currently published revision.
  - **review_revision** – UUID of the most recent review revision. Both fields
    are ``null`` when content is first created.
- - **state** – workflow state such as `Draft`, `AwaitingApproval`, `Published`, or `Archived`. Newly created items always start in the `Draft` state.
+ - **published_content** – dictionary storing the currently published attributes.
+ - **review_content** – dictionary storing attributes under review.
+ - **archived** – set to `true` when the item has been archived.
 - **file** – base64 encoded file contents (PDF only).
 - **pre_submission** – boolean that indicates a newly created PDF has not yet been submitted for approval.
 - **categories** – list of category UUIDs the content belongs to.
-
-```mermaid
-flowchart TD
-    Draft -->|request approval| AwaitingApproval
-    AwaitingApproval -->|approve| Published
-    Draft -.->|archive| Archived
-    Published -.->|archive| Archived
-```
 
 The API will automatically populate revision fields and enforce type validation as demonstrated in the tests.
 

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -48,7 +48,7 @@ def test_post_invalid_content_type(tmp_path):
     assert status == 200
     token = body["token"]
 
-    content = {"title": "Bad", "type": "unknown"}
+    content = {"review_content": {"title": "Bad"}, "type": "unknown"}
     status, body = _request(base_url, "POST", "/content", content, token=token)
     server.shutdown()
     thread.join()

--- a/tests/test_pdf_upload.py
+++ b/tests/test_pdf_upload.py
@@ -55,7 +55,7 @@ def test_upload_pdf_content(api_server, auth_token, users):
     encoded = base64.b64encode(pdf_bytes).decode()
 
     content = {
-        "title": "PDF Upload",
+        "review_content": {"title": "PDF Upload"},
         "type": ContentType.PDF.value,
         "file": encoded,
         "created_by": users["editor"]["uuid"],
@@ -74,7 +74,6 @@ def test_upload_pdf_content(api_server, auth_token, users):
     assert body["type"] == ContentType.PDF.value
     assert body["file"] == encoded
     assert "uuid" in body and body["uuid"]
-    assert body["state"] == "Draft"
     assert body["pre_submission"] is True
     assert body.get("published_revision") is None
     assert body.get("review_revision") is None

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -33,7 +33,7 @@ def _sample_content(content_type, users, idx):
     ts = "2025-06-08T12:00:00"
     content = {
         "uuid": str(uuid.uuid4()),
-        "title": f"{content_type.title()} Item {idx}",
+        "review_content": {"title": f"{content_type.title()} Item {idx}"},
         "type": content_type,
         "created_by": users["editor"]["uuid"],
         "created_at": ts,

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -58,7 +58,7 @@ def test_revision_history(api_server, users, auth_token):
 
     for i in range(3):
         updated = body.copy()
-        updated["title"] = f"Update {i}"
+        updated["review_content"] = {"title": f"Update {i}"}
         status, body = _request(api_server, "PUT", f"/content/{updated['uuid']}", updated, token=auth_token)
         assert status == 200
 


### PR DESCRIPTION
## Summary
- remove `state` workflow field
- add `published_content` and `review_content` dictionaries
- expose archived status via new `archived` flag
- adjust workflow helpers and API endpoints
- update docs and tests for new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ff27c6fc8322b86db681a01739d6