### PR TITLE
Refactor Python API to use service layer

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -1,17 +1,12 @@
 import json
-import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 from urllib.parse import urlparse, unquote
 
 from .types import ContentType
-from .workflow import (
-    check_required_metadata,
-    request_approval,
-    start_draft,
-    archive_content,
-    approve_content,
-)
+from .workflow import check_required_metadata
+from .db_context import DbContext
+from .services import CategoryService, ContentService, TokenService
 
 
 class SimpleCRUDHandler(BaseHTTPRequestHandler):
@@ -21,24 +16,20 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
     of the values defined in :class:`cms.types.ContentType`.
     """
 
-    store = {}
-    categories = {}
-    tokens = {}
+    context: DbContext
+    content_service: ContentService
+    category_service: CategoryService
+    token_service: TokenService
+
+    # Backwards compatible references to the underlying stores
+    store: dict
+    categories: dict
+    tokens: dict
+
     valid_types = {ct.value for ct in ContentType}
 
-    @staticmethod
-    def _sorted_categories():
-        def sort_key(cat):
-            prio = cat.get("display_priority", 0)
-            if prio and prio > 0:
-                return (0, prio)
-            return (1, cat.get("name", "").lower())
-
-        categories = [
-            c for c in SimpleCRUDHandler.categories.values() if not c.get("archived")
-        ]
-        categories.sort(key=sort_key)
-        return categories
+    def _sorted_categories(self):
+        return self.category_service.list_categories()
 
     @staticmethod
     def _valid_flat_category_list(categories):
@@ -49,44 +40,13 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             return False
         return all(isinstance(cat, str) for cat in categories)
 
-    @staticmethod
-    def _ensure_revision_structure(item):
-        """Populate revision fields if missing."""
-        if "revisions" not in item or not item["revisions"]:
-            rev_uuid = str(uuid.uuid4())
-            ts = item.get("timestamps") or item.get("metadata", {}).get("timestamps")
-            item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts}]
-        else:
-            for rev in item["revisions"]:
-                rev.setdefault(
-                    "last_updated", item.get("timestamps") or item.get("metadata", {}).get("timestamps")
-                )
-
-    @staticmethod
-    def _add_revision(item):
-        """Append a new revision entry reflecting the current content."""
-        rev_uuid = str(uuid.uuid4())
-        ts = (
-            item.get("edited_at")
-            or item.get("timestamps")
-            or item.get("metadata", {}).get("edited_at")
-            or item.get("metadata", {}).get("timestamps")
-        )
-        attrs = {}
-        if "title" in item:
-            attrs["title"] = item["title"]
-        if "file" in item:
-            attrs["file"] = item["file"]
-        item.setdefault("revisions", [])
-        item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
-        item["review_revision"] = rev_uuid
 
     def _authenticate(self):
         auth = self.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
             return False
         token = auth.split(" ", 1)[1]
-        return token in self.tokens
+        return self.token_service.validate_token(token)
 
     def _send_json(self, data, status=200):
         response = json.dumps(data).encode()
@@ -104,7 +64,7 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             return
         if parsed.path.startswith("/categories/"):
             cat_uuid = parsed.path.split("/")[-1]
-            cat = self.categories.get(cat_uuid)
+            cat = self.category_service.get_category(cat_uuid)
             if cat is None:
                 self._send_json({"error": "not found"}, status=404)
             else:
@@ -121,41 +81,27 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": "invalid type"}, status=400)
                 return
             authenticated = self._authenticate()
-            items = [
-                i
-                for i in self.store.values()
-                if i.get("type") == item_type
-                and (authenticated or i.get("state") == "Published")
-                and i.get("state") != "Archived"
-            ]
+            items = self.content_service.list_by_type(item_type, authenticated)
             self._send_json(items)
             return
         if parsed.path == "/pending-approvals":
             if not self._authenticate():
                 self._send_json({"error": "unauthorized"}, status=401)
                 return
-            pending = [
-                item for item in self.store.values()
-                if item.get("state") == "AwaitingApproval"
-            ]
+            pending = self.content_service.pending_approvals()
             self._send_json(pending)
             return
         if parsed.path == "/content":
             authenticated = self._authenticate()
-            items = [
-                item
-                for item in self.store.values()
-                if (authenticated or item.get("state") == "Published")
-                and item.get("state") != "Archived"
-            ]
+            items = self.content_service.list_all(authenticated)
             self._send_json(items)
             return
         if parsed.path.startswith("/content/"):
             if not self._authenticate():
                 self._send_json({"error": "unauthorized"}, status=401)
                 return
-            uuid = parsed.path.split("/")[-1]
-            item = self.store.get(uuid)
+            uuid_str = parsed.path.split("/")[-1]
+            item = self.content_service.get(uuid_str)
             if item is None:
                 self._send_json({"error": "not found"}, status=404)
             else:
@@ -172,8 +118,7 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             if not username:
                 self._send_json({"error": "username required"}, status=400)
                 return
-            token = f"token-{username}"
-            self.__class__.tokens[token] = username
+            token = self.token_service.create_token(username)
             self._send_json({"token": token})
             return
         parsed = urlparse(self.path)
@@ -192,88 +137,54 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             data = json.loads(body)
-            cat_uuid = data.get("uuid") or str(uuid.uuid4())
-            data["uuid"] = cat_uuid
-            self.categories[cat_uuid] = {
-                "uuid": cat_uuid,
-                "name": data.get("name", ""),
-                "display_priority": int(data.get("display_priority", 0)),
-                "archived": False,
-            }
-            self._send_json(self.categories[cat_uuid], status=201)
+            category = self.category_service.create_category(data)
+            self._send_json(category, status=201)
             return
         if parsed.path.startswith("/content/") and parsed.path.endswith("/request-approval"):
             if not self._authenticate():
                 self._send_json({"error": "unauthorized"}, status=401)
                 return
-            parts = parsed.path.split("/")
-            uuid_part = parts[2]
-            item = self.store.get(uuid_part)
-            if item is None:
-                self._send_json({"error": "not found"}, status=404)
-                return
-            self._ensure_revision_structure(item)
+            uuid_part = parsed.path.split("/")[2]
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             data = json.loads(body)
-            timestamp = data.get("timestamp")
-            user_uuid = data.get("user_uuid")
-            if not timestamp or not user_uuid:
-                self._send_json({"error": "invalid data"}, status=400)
-                return
-            request_approval(item, {"uuid": user_uuid}, timestamp)
-            self.store[uuid_part] = item
-            self._send_json(item)
+            item = self.content_service.request_approval(uuid_part, data)
+            if item is None:
+                self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(item)
             return
         if parsed.path.startswith("/content/") and parsed.path.endswith("/approve"):
             if not self._authenticate():
                 self._send_json({"error": "unauthorized"}, status=401)
                 return
-            parts = parsed.path.split("/")
-            uuid_part = parts[2]
-            item = self.store.get(uuid_part)
-            if item is None:
-                self._send_json({"error": "not found"}, status=404)
-                return
-            self._ensure_revision_structure(item)
+            uuid_part = parsed.path.split("/")[2]
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             data = json.loads(body)
-            timestamp = data.get("timestamp")
-            user_uuid = data.get("user_uuid")
-            if not timestamp or not user_uuid:
-                self._send_json({"error": "invalid data"}, status=400)
-                return
-            approve_content(item, {"uuid": user_uuid}, timestamp)
-            self.store[uuid_part] = item
-            self._send_json(item)
+            item = self.content_service.approve(uuid_part, data)
+            if item is None:
+                self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(item)
             return
         if parsed.path.startswith("/content/") and parsed.path.endswith("/start-draft"):
             if not self._authenticate():
                 self._send_json({"error": "unauthorized"}, status=401)
                 return
-            parts = parsed.path.split("/")
-            uuid_part = parts[2]
-            item = self.store.get(uuid_part)
-            if item is None:
-                self._send_json({"error": "not found"}, status=404)
-                return
-            self._ensure_revision_structure(item)
+            uuid_part = parsed.path.split("/")[2]
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             data = json.loads(body)
-            timestamp = data.get("timestamp")
-            user_uuid = data.get("user_uuid")
-            if not timestamp or not user_uuid:
-                self._send_json({"error": "invalid data"}, status=400)
-                return
             try:
-                start_draft(item, {"uuid": user_uuid}, timestamp)
+                item = self.content_service.start_draft(uuid_part, data)
             except PermissionError as exc:
                 self._send_json({"error": str(exc)}, status=403)
                 return
-            self.store[uuid_part] = item
-            self._send_json(item)
+            if item is None:
+                self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(item)
             return
         if parsed.path != "/content":
             self._send_json({"error": "not found"}, status=404)
@@ -302,41 +213,21 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             self._send_json({"error": str(exc)}, status=400)
             return
 
-        item_uuid = item.get("uuid")
-        if not item_uuid:
-            item_uuid = str(uuid.uuid4())
-            item["uuid"] = item_uuid
-
-        # all newly created content should begin in Draft state
-        item["state"] = "Draft"
-
-        # PDFs should start in Draft/pre-submission state
-        if item.get("type") == "pdf":
-            item["pre_submission"] = True
-
-        self._ensure_revision_structure(item)
-
-        self.store[item_uuid] = item
-        self._send_json(item, status=201)
+        created = self.content_service.create(item)
+        self._send_json(created, status=201)
 
     def do_PUT(self):
         parsed = urlparse(self.path)
         if parsed.path.startswith("/categories/"):
             cat_uuid = parsed.path.split("/")[-1]
-            if cat_uuid not in self.categories:
-                self._send_json({"error": "not found"}, status=404)
-                return
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             incoming = json.loads(body)
-            existing = self.categories[cat_uuid]
-            updated = existing.copy()
-            updated.update({
-                "name": incoming.get("name", existing.get("name")),
-                "display_priority": int(incoming.get("display_priority", existing.get("display_priority", 0))),
-            })
-            self.categories[cat_uuid] = updated
-            self._send_json(updated)
+            updated = self.category_service.update_category(cat_uuid, incoming)
+            if updated is None:
+                self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(updated)
             return
         if parsed.path.startswith("/content/"):
             if not self._authenticate():
@@ -350,51 +241,22 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
             body = self.rfile.read(length)
             incoming = json.loads(body)
 
-            existing = self.store[uuid]
-
-            # type field is immutable
-            new_type = incoming.get("type", existing.get("type"))
-            if new_type != existing.get("type"):
-                self._send_json({"error": "type cannot be changed"}, status=400)
-                return
-
             if not self._valid_flat_category_list(incoming.get("categories")):
                 self._send_json(
                     {"error": "categories must be a flat list of strings"}, status=400
                 )
                 return
 
-            # metadata fields are immutable via this endpoint
-            metadata_fields = {
-                "created_by",
-                "created_at",
-                "edited_by",
-                "edited_at",
-                "draft_requested_by",
-                "draft_requested_at",
-                "approved_by",
-                "approved_at",
-                "timestamps",
-            }
+            try:
+                updated = self.content_service.update(uuid, incoming)
+            except ValueError as exc:
+                self._send_json({"error": str(exc)}, status=400)
+                return
 
-            # support old structure
-            if incoming.get("metadata") is not None:
-                if incoming.get("metadata") != existing.get("metadata"):
-                    self._send_json({"error": "metadata immutable"}, status=400)
-                    return
+            if updated is None:
+                self._send_json({"error": "not found"}, status=404)
             else:
-                for field in metadata_fields:
-                    if field in incoming and incoming[field] != existing.get(field):
-                        self._send_json({"error": "metadata immutable"}, status=400)
-                        return
-
-            updated = existing.copy()
-            excluded = metadata_fields | {"type", "metadata", "uuid"}
-            updated.update({k: v for k, v in incoming.items() if k not in excluded})
-            self._ensure_revision_structure(updated)
-            self._add_revision(updated)
-            self.store[uuid] = updated
-            self._send_json(updated)
+                self._send_json(updated)
         else:
             self._send_json({"error": "not found"}, status=404)
 
@@ -402,35 +264,37 @@ class SimpleCRUDHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         if parsed.path.startswith("/categories/"):
             cat_uuid = parsed.path.split("/")[-1]
-            cat = self.categories.get(cat_uuid)
-            if cat is not None:
-                cat["archived"] = True
-                self.categories[cat_uuid] = cat
-                self._send_json(cat)
-            else:
+            cat = self.category_service.archive_category(cat_uuid)
+            if cat is None:
                 self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(cat)
             return
         if parsed.path.startswith("/content/"):
             if not self._authenticate():
                 self._send_json({"error": "unauthorized"}, status=401)
                 return
             uuid = parsed.path.split("/")[-1]
-            if uuid in self.store:
-                item = self.store[uuid]
-                archive_content(item)
-                self.store[uuid] = item
-                self._send_json(item)
-            else:
+            item = self.content_service.archive(uuid)
+            if item is None:
                 self._send_json({"error": "not found"}, status=404)
+            else:
+                self._send_json(item)
         else:
             self._send_json({"error": "not found"}, status=404)
 
 
 def start_test_server(port=0):
     """Start the CRUD HTTP server on a background thread."""
-    SimpleCRUDHandler.store = {}
-    SimpleCRUDHandler.categories = {}
-    SimpleCRUDHandler.tokens = {}
+    context = DbContext()
+    SimpleCRUDHandler.context = context
+    SimpleCRUDHandler.content_service = ContentService(context)
+    SimpleCRUDHandler.category_service = CategoryService(context)
+    SimpleCRUDHandler.token_service = TokenService(context)
+    # expose raw stores for backward compatibility
+    SimpleCRUDHandler.store = context.contents
+    SimpleCRUDHandler.categories = context.categories
+    SimpleCRUDHandler.tokens = context.tokens
     server = HTTPServer(("localhost", port), SimpleCRUDHandler)
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/cms/db_context.py
+++ b/cms/db_context.py
@@ -1,0 +1,7 @@
+class DbContext:
+    """Mimic an Entity Framework style DbContext using in-memory stores."""
+
+    def __init__(self):
+        self.contents = {}
+        self.categories = {}
+        self.tokens = {}

--- a/cms/services.py
+++ b/cms/services.py
@@ -1,0 +1,211 @@
+import uuid
+from typing import Dict, List
+
+from .db_context import DbContext
+from .workflow import (
+    check_required_metadata,
+    request_approval,
+    start_draft,
+    archive_content,
+    approve_content,
+)
+
+
+class CategoryService:
+    def __init__(self, ctx: DbContext):
+        self.ctx = ctx
+
+    def list_categories(self) -> List[Dict]:
+        def sort_key(cat):
+            prio = cat.get("display_priority", 0)
+            if prio and prio > 0:
+                return (0, prio)
+            return (1, cat.get("name", "").lower())
+
+        categories = [c for c in self.ctx.categories.values() if not c.get("archived")]
+        categories.sort(key=sort_key)
+        return categories
+
+    def get_category(self, uuid: str) -> Dict:
+        return self.ctx.categories.get(uuid)
+
+    def create_category(self, data: Dict) -> Dict:
+        cat_uuid = data.get("uuid") or str(uuid.uuid4())
+        category = {
+            "uuid": cat_uuid,
+            "name": data.get("name", ""),
+            "display_priority": int(data.get("display_priority", 0)),
+            "archived": False,
+        }
+        self.ctx.categories[cat_uuid] = category
+        return category
+
+    def update_category(self, uuid: str, data: Dict) -> Dict:
+        existing = self.ctx.categories.get(uuid)
+        if existing is None:
+            return None
+        updated = existing.copy()
+        updated.update({
+            "name": data.get("name", existing.get("name")),
+            "display_priority": int(data.get("display_priority", existing.get("display_priority", 0))),
+        })
+        self.ctx.categories[uuid] = updated
+        return updated
+
+    def archive_category(self, uuid: str) -> Dict:
+        cat = self.ctx.categories.get(uuid)
+        if cat is not None:
+            cat["archived"] = True
+            self.ctx.categories[uuid] = cat
+        return cat
+
+
+class ContentService:
+    def __init__(self, ctx: DbContext):
+        self.ctx = ctx
+
+    def list_all(self, authenticated: bool) -> List[Dict]:
+        return [
+            item
+            for item in self.ctx.contents.values()
+            if (authenticated or item.get("state") == "Published")
+            and item.get("state") != "Archived"
+        ]
+
+    def list_by_type(self, item_type: str, authenticated: bool) -> List[Dict]:
+        return [
+            i
+            for i in self.ctx.contents.values()
+            if i.get("type") == item_type
+            and (authenticated or i.get("state") == "Published")
+            and i.get("state") != "Archived"
+        ]
+
+    def get(self, uuid: str) -> Dict:
+        return self.ctx.contents.get(uuid)
+
+    # Internal helpers -------------------------------------------------
+    @staticmethod
+    def _ensure_revision_structure(item: Dict):
+        if "revisions" not in item or not item["revisions"]:
+            rev_uuid = str(uuid.uuid4())
+            ts = item.get("timestamps") or item.get("metadata", {}).get("timestamps")
+            item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts}]
+        else:
+            for rev in item["revisions"]:
+                rev.setdefault(
+                    "last_updated", item.get("timestamps") or item.get("metadata", {}).get("timestamps")
+                )
+
+    @staticmethod
+    def _add_revision(item: Dict):
+        rev_uuid = str(uuid.uuid4())
+        ts = (
+            item.get("edited_at")
+            or item.get("timestamps")
+            or item.get("metadata", {}).get("edited_at")
+            or item.get("metadata", {}).get("timestamps")
+        )
+        attrs = {}
+        if "title" in item:
+            attrs["title"] = item["title"]
+        if "file" in item:
+            attrs["file"] = item["file"]
+        item.setdefault("revisions", [])
+        item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
+        item["review_revision"] = rev_uuid
+
+    def create(self, item: Dict) -> Dict:
+        item_uuid = item.get("uuid") or str(uuid.uuid4())
+        item["uuid"] = item_uuid
+        item["state"] = "Draft"
+        if item.get("type") == "pdf":
+            item["pre_submission"] = True
+        self._ensure_revision_structure(item)
+        self.ctx.contents[item_uuid] = item
+        return item
+
+    def update(self, uuid: str, incoming: Dict) -> Dict:
+        existing = self.ctx.contents.get(uuid)
+        if existing is None:
+            return None
+        new_type = incoming.get("type", existing.get("type"))
+        if new_type != existing.get("type"):
+            raise ValueError("type cannot be changed")
+
+        metadata_fields = {
+            "created_by",
+            "created_at",
+            "edited_by",
+            "edited_at",
+            "draft_requested_by",
+            "draft_requested_at",
+            "approved_by",
+            "approved_at",
+            "timestamps",
+        }
+        if incoming.get("metadata") is not None:
+            if incoming.get("metadata") != existing.get("metadata"):
+                raise ValueError("metadata immutable")
+        else:
+            for field in metadata_fields:
+                if field in incoming and incoming[field] != existing.get(field):
+                    raise ValueError("metadata immutable")
+
+        updated = existing.copy()
+        excluded = metadata_fields | {"type", "metadata", "uuid"}
+        updated.update({k: v for k, v in incoming.items() if k not in excluded})
+        self._ensure_revision_structure(updated)
+        self._add_revision(updated)
+        self.ctx.contents[uuid] = updated
+        return updated
+
+    def archive(self, uuid: str) -> Dict:
+        item = self.ctx.contents.get(uuid)
+        if item is not None:
+            archive_content(item)
+            self.ctx.contents[uuid] = item
+        return item
+
+    def request_approval(self, uuid: str, data: Dict) -> Dict:
+        item = self.ctx.contents.get(uuid)
+        if item is None:
+            return None
+        self._ensure_revision_structure(item)
+        request_approval(item, {"uuid": data.get("user_uuid")}, data.get("timestamp"))
+        self.ctx.contents[uuid] = item
+        return item
+
+    def approve(self, uuid: str, data: Dict) -> Dict:
+        item = self.ctx.contents.get(uuid)
+        if item is None:
+            return None
+        self._ensure_revision_structure(item)
+        approve_content(item, {"uuid": data.get("user_uuid")}, data.get("timestamp"))
+        self.ctx.contents[uuid] = item
+        return item
+
+    def start_draft(self, uuid: str, data: Dict) -> Dict:
+        item = self.ctx.contents.get(uuid)
+        if item is None:
+            return None
+        self._ensure_revision_structure(item)
+        start_draft(item, {"uuid": data.get("user_uuid")}, data.get("timestamp"))
+        self.ctx.contents[uuid] = item
+        return item
+
+    def pending_approvals(self) -> List[Dict]:
+        return [item for item in self.ctx.contents.values() if item.get("state") == "AwaitingApproval"]
+
+
+class TokenService:
+    def __init__(self, ctx: DbContext):
+        self.ctx = ctx
+
+    def create_token(self, username: str) -> str:
+        token = f"token-{username}"
+        self.ctx.tokens[token] = username
+        return token
+
+    def validate_token(self, token: str) -> bool:
+        return token in self.ctx.tokens


### PR DESCRIPTION
## Summary
- introduce a `DbContext` object for in-memory data
- add `services` module implementing content/category/token services
- refactor `api` module to delegate CRUD logic to services and initialize them in `start_test_server`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846071bd0c88322b8e239cfaae8e28a