### PR TITLE
Improve internal model documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ All content types share the same metadata and revision structure:
 Requests that create or update content must specify one of these values for the
 `type` field.
 
+## Internal Data Model
+
+While the HTTP interface exchanges JSON, the CMS logic itself works with
+dataclass models defined in `cms.models`.  These classes mimic an
+Entity&nbsp;Framework style of programming where a lightweight
+`DbContext` holds sets of `Content`, `Revision` and `Category` objects in
+memory.  Services operate on these objects and convert them to plain
+dictionaries only when sending responses through the API.  This keeps the
+implementation structured and type‑safe without relying on JSON for
+in‑process data.
+
 ## Running the Tests
 
 Install `pytest` if it is not already available:

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -1,6 +1,10 @@
 # Data Structure
 
-This document describes the JSON schema used for content items stored by the CMS workflow API.
+This document describes the data model used by the CMS workflow API.  While the
+HTTP interface exchanges JSON, the implementation stores content as dataclass
+objects in a small `DbContext` container.  The following diagrams show the
+fields present on those dataclasses as well as the JSON shape returned over the
+wire.
 
 ```mermaid
 classDiagram
@@ -76,3 +80,12 @@ Category objects returned by the API contain:
 - **archived** – set to `true` when the category has been removed from active use.
 
 Categories are **flat**; the API does not currently support parent/child relationships.
+
+### Dataclass Representation
+
+For in‑process operations the code uses dataclass models from
+`cms.models`.  The `DbContext` class exposes simple dictionaries mapping
+UUIDs to instances of these dataclasses.  When the HTTP layer sends or
+receives data, the service layer converts between dataclass objects and
+plain dictionaries so that the external JSON structure matches the
+schema described above.


### PR DESCRIPTION
## Summary
- note that the workflow stores dataclass objects
- describe use of `DbContext` and dataclass conversions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846096da3e48322a7a47ef660597c0b