### PR TITLE
Store PDF file per revision

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -34,7 +34,6 @@ class Content:
     published_revision: Optional[str] = None
     review_revision: Optional[str] = None
     archived: bool = False
-    file: Optional[str] = None
     pre_submission: Optional[bool] = None
     categories: List[str] = field(default_factory=list)
 

--- a/cms/services.py
+++ b/cms/services.py
@@ -97,7 +97,12 @@ class ContentService:
         if "revisions" not in item or not item["revisions"]:
             rev_uuid = str(uuid.uuid4())
             ts = item.get("timestamps") or item.get("metadata", {}).get("timestamps")
-            item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts}]
+            attrs = {}
+            if "title" in item:
+                attrs["title"] = item["title"]
+            if "file" in item:
+                attrs["file"] = item.pop("file")
+            item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts, "attributes": attrs}]
         else:
             for rev in item["revisions"]:
                 rev.setdefault(
@@ -117,7 +122,7 @@ class ContentService:
         if "title" in item:
             attrs["title"] = item["title"]
         if "file" in item:
-            attrs["file"] = item["file"]
+            attrs["file"] = item.pop("file")
         item.setdefault("revisions", [])
         item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
         item["review_revision"] = rev_uuid

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -25,7 +25,6 @@ classDiagram
         published_revision: str
         review_revision: str
         archived: bool
-        file: str
         pre_submission: bool
         categories: List[str]
     }
@@ -55,12 +54,14 @@ classDiagram
  - **published_revision** – UUID of the currently published revision.
  - **review_revision** – UUID of the most recent review revision. Both fields
    are ``null`` when content is first created.
- - **is_published** – boolean computed by the service layer. Set to `true` when
-   ``published_revision`` is assigned.
- - **archived** – set to `true` when the content has been removed from active use.
-- **file** – base64 encoded file contents (PDF only).
+- **is_published** – boolean computed by the service layer. Set to `true` when
+  ``published_revision`` is assigned.
+- **archived** – set to `true` when the content has been removed from active use.
 - **pre_submission** – boolean that indicates a newly created PDF has not yet been submitted for approval.
 - **categories** – list of category UUIDs the content belongs to.
+
+Each revision's ``attributes`` dictionary stores type-specific fields. For PDF content
+the ``file`` attribute contains a UUID referencing the uploaded file.
 
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,5 +1,4 @@
 import json
-import base64
 import os
 import sys
 import urllib.request
@@ -40,7 +39,7 @@ def _sample_content(content_type, users, idx):
         "timestamps": ts,
     }
     if content_type == ContentType.PDF.value:
-        content["file"] = base64.b64encode(f"pdf-{idx}".encode()).decode()
+        content["file"] = str(uuid.uuid4())
     elif content_type == ContentType.OFFICE_ADDRESS.value:
         content["address"] = f"{idx} Example Rd." 
     elif content_type == ContentType.EVENT_SCHEDULE.value:


### PR DESCRIPTION
## Summary
- remove file field from top-level content model
- include `file` attribute inside revision details
- update docs to explain file UUIDs in revisions
- adjust services to handle file attribute migration
- update PDF tests for file UUIDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684614a308cc8322b69acd000636c7b7