### PR TITLE
Add file_uuid for PDF content type

### DIFF
--- a/cms/services.py
+++ b/cms/services.py
@@ -99,8 +99,8 @@ class ContentService:
             attrs = {}
             if "title" in item:
                 attrs["title"] = item["title"]
-            if "file" in item:
-                attrs["file"] = item.pop("file")
+            if "file_uuid" in item:
+                attrs["file_uuid"] = item.pop("file_uuid")
             item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts, "attributes": attrs}]
         else:
             for rev in item["revisions"]:
@@ -120,8 +120,8 @@ class ContentService:
         attrs = {}
         if "title" in item:
             attrs["title"] = item["title"]
-        if "file" in item:
-            attrs["file"] = item.pop("file")
+        if "file_uuid" in item:
+            attrs["file_uuid"] = item.pop("file_uuid")
         item.setdefault("revisions", [])
         item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
         item["review_revision"] = rev_uuid

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -61,7 +61,7 @@ classDiagram
 Soft deleting a content item clears both ``published_revision`` and ``review_revision`` so that it no longer appears as published or under review.
 
 Each revision's ``attributes`` dictionary stores type-specific fields. For PDF content
-the ``file`` attribute contains a UUID referencing the uploaded file.
+the ``file_uuid`` attribute contains a UUID referencing the uploaded file.
 
 
 

--- a/tests/test_pdf_upload.py
+++ b/tests/test_pdf_upload.py
@@ -56,7 +56,7 @@ def test_upload_pdf_content(api_server, auth_token, users):
     content = {
         "title": "PDF Upload",
         "type": ContentType.PDF.value,
-        "file": file_id,
+        "file_uuid": file_id,
         "created_by": users["editor"]["uuid"],
         "created_at": "2025-06-09T12:00:00",
         "edited_by": None,
@@ -71,9 +71,9 @@ def test_upload_pdf_content(api_server, auth_token, users):
     status, body = _request(api_server, "POST", "/content", content, token=auth_token)
     assert status == 201
     assert body["type"] == ContentType.PDF.value
-    assert "file" not in body
+    assert "file_uuid" not in body
     latest_rev = body["revisions"][-1]
-    assert latest_rev["attributes"]["file"] == file_id
+    assert latest_rev["attributes"]["file_uuid"] == file_id
     assert "uuid" in body and body["uuid"]
     assert body["is_published"] is False
     assert body["review_requested"] is False

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -39,7 +39,7 @@ def _sample_content(content_type, users, idx):
         "timestamps": ts,
     }
     if content_type == ContentType.PDF.value:
-        content["file"] = str(uuid.uuid4())
+        content["file_uuid"] = str(uuid.uuid4())
     elif content_type == ContentType.OFFICE_ADDRESS.value:
         content["address"] = f"{idx} Example Rd." 
     elif content_type == ContentType.EVENT_SCHEDULE.value:


### PR DESCRIPTION
## Summary
- support `file_uuid` attribute when creating or updating PDF content
- update docs to mention `file_uuid`
- adjust PDF tests to use the new attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684628a150dc8322a96f5891a3c6f2ac