### PR TITLE
Add file_uuid to seeded PDF revisions

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -44,10 +44,13 @@ def seed_example_contents(users):
     contents = []
     for ct in ContentType:
         for _ in range(2):
+            rev_attrs = {"title": f"Example {ct.value}"}
+            if ct is ContentType.PDF:
+                rev_attrs["file_uuid"] = str(uuid.uuid4())
             rev = Revision(
                 uuid=str(uuid.uuid4()),
                 last_updated=timestamp,
-                attributes={"title": f"Example {ct.value}"},
+                attributes=rev_attrs,
             )
             base_kwargs = dict(
                 uuid=str(uuid.uuid4()),

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -20,5 +20,8 @@ def test_seed_example_contents():
         uuids.add(item.uuid)
         # ensure dataclass to_dict works
         assert item.to_dict()["type"] == item.type.value
+        if item.type is ContentType.PDF:
+            for rev in item.revisions:
+                assert "file_uuid" in rev.attributes and rev.attributes["file_uuid"]
     assert all(count >= 2 for count in type_counts.values())
     assert len(uuids) == len(contents)


### PR DESCRIPTION
## Summary
- when seeding example data, populate `file_uuid` on PDF revisions
- verify seeded PDF content includes a `file_uuid`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462a68f530832290339c247497260c