### PR TITLE
Ensure PDF revisions retain file_uuid

### DIFF
--- a/cms/services.py
+++ b/cms/services.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import Dict, List
 
+from .types import ContentType
+
 from .db_context import DbContext
 from .workflow import (
     check_required_metadata,
@@ -122,6 +124,10 @@ class ContentService:
             attrs["title"] = item["title"]
         if "file_uuid" in item:
             attrs["file_uuid"] = item.pop("file_uuid")
+        elif item.get("type") == ContentType.PDF.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "file_uuid" in last:
+                attrs["file_uuid"] = last["file_uuid"]
         item.setdefault("revisions", [])
         item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
         item["review_revision"] = rev_uuid

--- a/tests/test_pdf_file_uuid.py
+++ b/tests/test_pdf_file_uuid.py
@@ -1,0 +1,75 @@
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cms.data import seed_users
+from cms.types import ContentType
+from cms.api import start_test_server
+
+
+@pytest.fixture()
+def users():
+    return seed_users()
+
+
+@pytest.fixture()
+def api_server():
+    server, thread = start_test_server()
+    base_url = f"http://localhost:{server.server_port}"
+    yield base_url
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture()
+def auth_token(api_server):
+    status, body = _request(api_server, "POST", "/test-token", {"username": "tester"})
+    assert status == 200
+    return body["token"]
+
+
+def _request(base_url, method, path, data=None, token=None):
+    url = base_url + path
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode())
+
+
+def test_pdf_revisions_include_file_uuid(api_server, auth_token, users):
+    file_id = str(uuid.uuid4())
+    content = {
+        "title": "PDF Upload",
+        "type": ContentType.PDF.value,
+        "file_uuid": file_id,
+        "created_by": users["editor"]["uuid"],
+        "created_at": "2025-06-09T12:00:00",
+        "timestamps": "2025-06-09T12:00:00",
+    }
+    status, body = _request(api_server, "POST", "/content", content, token=auth_token)
+    assert status == 201
+    item_uuid = body["uuid"]
+
+    updated = body.copy()
+    updated["title"] = "Updated Title"
+    status, body = _request(api_server, "PUT", f"/content/{item_uuid}", updated, token=auth_token)
+    assert status == 200
+
+    status, body = _request(api_server, "GET", f"/content/{item_uuid}", token=auth_token)
+    assert status == 200
+    for rev in body["revisions"]:
+        assert "file_uuid" in rev["attributes"]


### PR DESCRIPTION
## Summary
- preserve `file_uuid` when creating revisions for PDF content
- add regression test validating every revision of PDF items includes the `file_uuid`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68462f91f46483229614e89892a41bf2