### PR TITLE
Add html content revisions

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -25,7 +25,7 @@ def sample_content(users):
     revision = Revision(
         uuid=revision_uuid,
         last_updated=timestamp,
-        attributes={"title": "Sample HTML Content"},
+        attributes={"title": "Sample HTML Content", "html_content": "<p>Sample HTML Content</p>"},
     )
     return HTMLContent(
         uuid=str(uuid.uuid4()),
@@ -45,6 +45,8 @@ def seed_example_contents(users):
     for ct in ContentType:
         for _ in range(2):
             rev_attrs = {"title": f"Example {ct.value}"}
+            if ct is ContentType.HTML:
+                rev_attrs["html_content"] = f"<p>Example {ct.value}</p>"
             if ct is ContentType.PDF:
                 # include a file UUID for seeded PDF content
                 rev_attrs["file_uuid"] = str(uuid.uuid4())

--- a/cms/services.py
+++ b/cms/services.py
@@ -103,6 +103,8 @@ class ContentService:
                 attrs["title"] = item["title"]
             if "file_uuid" in item:
                 attrs["file_uuid"] = item.pop("file_uuid")
+            if "html_content" in item:
+                attrs["html_content"] = item.pop("html_content")
             item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts, "attributes": attrs}]
         else:
             for rev in item["revisions"]:
@@ -128,6 +130,12 @@ class ContentService:
             last = item["revisions"][-1].get("attributes", {})
             if "file_uuid" in last:
                 attrs["file_uuid"] = last["file_uuid"]
+        if "html_content" in item:
+            attrs["html_content"] = item.pop("html_content")
+        elif item.get("type") == ContentType.HTML.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "html_content" in last:
+                attrs["html_content"] = last["html_content"]
         item.setdefault("revisions", [])
         item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
         item["review_revision"] = rev_uuid

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -61,7 +61,8 @@ classDiagram
 Soft deleting a content item clears both ``published_revision`` and ``review_revision`` so that it no longer appears as published or under review.
 
 Each revision's ``attributes`` dictionary stores type-specific fields. For PDF content
-the ``file_uuid`` attribute contains a UUID referencing the uploaded file.
+the ``file_uuid`` attribute contains a UUID referencing the uploaded file. For HTML
+content the ``html_content`` attribute stores the markup string for that revision.
 
 
 

--- a/tests/test_html_content.py
+++ b/tests/test_html_content.py
@@ -1,0 +1,74 @@
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cms.data import seed_users
+from cms.types import ContentType
+from cms.api import start_test_server
+
+
+@pytest.fixture()
+def users():
+    return seed_users()
+
+
+@pytest.fixture()
+def api_server():
+    server, thread = start_test_server()
+    base_url = f"http://localhost:{server.server_port}"
+    yield base_url
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture()
+def auth_token(api_server):
+    status, body = _request(api_server, "POST", "/test-token", {"username": "tester"})
+    assert status == 200
+    return body["token"]
+
+
+def _request(base_url, method, path, data=None, token=None):
+    url = base_url + path
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode())
+
+
+def test_html_revisions_include_html_content(api_server, auth_token, users):
+    content = {
+        "title": "HTML Upload",
+        "type": ContentType.HTML.value,
+        "html_content": "<p>Hello</p>",
+        "created_by": users["editor"]["uuid"],
+        "created_at": "2025-06-09T12:00:00",
+        "timestamps": "2025-06-09T12:00:00",
+    }
+    status, body = _request(api_server, "POST", "/content", content, token=auth_token)
+    assert status == 201
+    item_uuid = body["uuid"]
+
+    updated = body.copy()
+    updated["title"] = "Updated Title"
+    status, body = _request(api_server, "PUT", f"/content/{item_uuid}", updated, token=auth_token)
+    assert status == 200
+
+    status, body = _request(api_server, "GET", f"/content/{item_uuid}", token=auth_token)
+    assert status == 200
+    for rev in body["revisions"]:
+        assert "html_content" in rev["attributes"]


### PR DESCRIPTION
## Summary
- ensure html content moves into revision attributes on create/update
- include example html content in sample data
- document the html_content revision field
- test html content attribute handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463088235c83228547a666dfae6dfc