### PR TITLE
Add event schedule revision fields

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -50,6 +50,14 @@ def seed_example_contents(users):
             if ct is ContentType.PDF:
                 # include a file UUID for seeded PDF content
                 rev_attrs["file_uuid"] = str(uuid.uuid4())
+            if ct is ContentType.EVENT_SCHEDULE:
+                rev_attrs.update(
+                    {
+                        "start": "2025-06-08T09:00:00",
+                        "end": "2025-06-08T10:00:00",
+                        "all_day": False,
+                    }
+                )
             rev = Revision(
                 uuid=str(uuid.uuid4()),
                 last_updated=timestamp,

--- a/cms/services.py
+++ b/cms/services.py
@@ -105,6 +105,12 @@ class ContentService:
                 attrs["file_uuid"] = item.pop("file_uuid")
             if "html_content" in item:
                 attrs["html_content"] = item.pop("html_content")
+            if "start" in item:
+                attrs["start"] = item.pop("start")
+            if "end" in item:
+                attrs["end"] = item.pop("end")
+            if "all_day" in item:
+                attrs["all_day"] = item.pop("all_day")
             item["revisions"] = [{"uuid": rev_uuid, "last_updated": ts, "attributes": attrs}]
         else:
             for rev in item["revisions"]:
@@ -136,6 +142,24 @@ class ContentService:
             last = item["revisions"][-1].get("attributes", {})
             if "html_content" in last:
                 attrs["html_content"] = last["html_content"]
+        if "start" in item:
+            attrs["start"] = item.pop("start")
+        elif item.get("type") == ContentType.EVENT_SCHEDULE.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "start" in last:
+                attrs["start"] = last["start"]
+        if "end" in item:
+            attrs["end"] = item.pop("end")
+        elif item.get("type") == ContentType.EVENT_SCHEDULE.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "end" in last:
+                attrs["end"] = last["end"]
+        if "all_day" in item:
+            attrs["all_day"] = item.pop("all_day")
+        elif item.get("type") == ContentType.EVENT_SCHEDULE.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "all_day" in last:
+                attrs["all_day"] = last["all_day"]
         item.setdefault("revisions", [])
         item["revisions"].append({"uuid": rev_uuid, "last_updated": ts, "attributes": attrs})
         item["review_revision"] = rev_uuid

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -63,6 +63,8 @@ Soft deleting a content item clears both ``published_revision`` and ``review_rev
 Each revision's ``attributes`` dictionary stores type-specific fields. For PDF content
 the ``file_uuid`` attribute contains a UUID referencing the uploaded file. For HTML
 content the ``html_content`` attribute stores the markup string for that revision.
+For ``event schedule`` content the attributes ``start`` and ``end`` store ISO
+datetime strings while ``all_day`` is a boolean flag.
 
 
 

--- a/tests/test_event_schedule_fields.py
+++ b/tests/test_event_schedule_fields.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import json
+import urllib.request
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cms.data import seed_users
+from cms.types import ContentType
+from cms.api import start_test_server
+
+
+@pytest.fixture()
+def users():
+    return seed_users()
+
+
+@pytest.fixture()
+def api_server():
+    server, thread = start_test_server()
+    base_url = f"http://localhost:{server.server_port}"
+    yield base_url
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture()
+def auth_token(api_server):
+    status, body = _request(api_server, "POST", "/test-token", {"username": "tester"})
+    assert status == 200
+    return body["token"]
+
+
+def _request(base_url, method, path, data=None, token=None):
+    url = base_url + path
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode())
+
+
+def test_event_schedule_revisions_include_fields(api_server, auth_token, users):
+    content = {
+        "title": "Event Schedule",
+        "type": ContentType.EVENT_SCHEDULE.value,
+        "start": "2025-06-10T09:00:00",
+        "end": "2025-06-10T11:00:00",
+        "all_day": False,
+        "created_by": users["editor"]["uuid"],
+        "created_at": "2025-06-09T12:00:00",
+        "timestamps": "2025-06-09T12:00:00",
+    }
+    status, body = _request(api_server, "POST", "/content", content, token=auth_token)
+    assert status == 201
+    item_uuid = body["uuid"]
+
+    updated = body.copy()
+    updated["title"] = "Updated Title"
+    status, body = _request(api_server, "PUT", f"/content/{item_uuid}", updated, token=auth_token)
+    assert status == 200
+
+    status, body = _request(api_server, "GET", f"/content/{item_uuid}", token=auth_token)
+    assert status == 200
+    for rev in body["revisions"]:
+        attrs = rev["attributes"]
+        assert "start" in attrs
+        assert "end" in attrs
+        assert "all_day" in attrs

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -43,7 +43,10 @@ def _sample_content(content_type, users, idx):
     elif content_type == ContentType.OFFICE_ADDRESS.value:
         content["address"] = f"{idx} Example Rd." 
     elif content_type == ContentType.EVENT_SCHEDULE.value:
-        content["event_date"] = f"2025-06-{10 + idx:02d}T09:00:00"
+        start = f"2025-06-{10 + idx:02d}T09:00:00"
+        content["start"] = start
+        content["end"] = f"2025-06-{10 + idx:02d}T17:00:00"
+        content["all_day"] = False
     else:
         content["body"] = f"<p>Example HTML {idx}</p>"
     return content


### PR DESCRIPTION
## Summary
- enforce `start`, `end` and `all_day` fields in event schedule revisions
- seed example event schedule data with these fields
- document event schedule attributes
- update publish helper for event schedules
- test event schedule revisions include these fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463be88fb883229e470a8a4baa8f52