### PR TITLE
Add office address revision fields

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -50,6 +50,16 @@ def seed_example_contents(users):
             if ct is ContentType.PDF:
                 # include a file UUID for seeded PDF content
                 rev_attrs["file_uuid"] = str(uuid.uuid4())
+            if ct is ContentType.OFFICE_ADDRESS:
+                rev_attrs.update(
+                    {
+                        "postal_code": "00000",
+                        "address": "123 Example Rd.",
+                        "phone": "555-0000",
+                        "fax": "555-0001",
+                        "email": "info@example.com",
+                    }
+                )
             if ct is ContentType.EVENT_SCHEDULE:
                 rev_attrs.update(
                     {

--- a/cms/services.py
+++ b/cms/services.py
@@ -105,6 +105,16 @@ class ContentService:
                 attrs["file_uuid"] = item.pop("file_uuid")
             if "html_content" in item:
                 attrs["html_content"] = item.pop("html_content")
+            if "postal_code" in item:
+                attrs["postal_code"] = item.pop("postal_code")
+            if "address" in item:
+                attrs["address"] = item.pop("address")
+            if "phone" in item:
+                attrs["phone"] = item.pop("phone")
+            if "fax" in item:
+                attrs["fax"] = item.pop("fax")
+            if "email" in item:
+                attrs["email"] = item.pop("email")
             if "start" in item:
                 attrs["start"] = item.pop("start")
             if "end" in item:
@@ -142,6 +152,36 @@ class ContentService:
             last = item["revisions"][-1].get("attributes", {})
             if "html_content" in last:
                 attrs["html_content"] = last["html_content"]
+        if "postal_code" in item:
+            attrs["postal_code"] = item.pop("postal_code")
+        elif item.get("type") == ContentType.OFFICE_ADDRESS.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "postal_code" in last:
+                attrs["postal_code"] = last["postal_code"]
+        if "address" in item:
+            attrs["address"] = item.pop("address")
+        elif item.get("type") == ContentType.OFFICE_ADDRESS.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "address" in last:
+                attrs["address"] = last["address"]
+        if "phone" in item:
+            attrs["phone"] = item.pop("phone")
+        elif item.get("type") == ContentType.OFFICE_ADDRESS.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "phone" in last:
+                attrs["phone"] = last["phone"]
+        if "fax" in item:
+            attrs["fax"] = item.pop("fax")
+        elif item.get("type") == ContentType.OFFICE_ADDRESS.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "fax" in last:
+                attrs["fax"] = last["fax"]
+        if "email" in item:
+            attrs["email"] = item.pop("email")
+        elif item.get("type") == ContentType.OFFICE_ADDRESS.value and item.get("revisions"):
+            last = item["revisions"][-1].get("attributes", {})
+            if "email" in last:
+                attrs["email"] = last["email"]
         if "start" in item:
             attrs["start"] = item.pop("start")
         elif item.get("type") == ContentType.EVENT_SCHEDULE.value and item.get("revisions"):

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -65,6 +65,7 @@ the ``file_uuid`` attribute contains a UUID referencing the uploaded file. For H
 content the ``html_content`` attribute stores the markup string for that revision.
 For ``event schedule`` content the attributes ``start`` and ``end`` store ISO
 datetime strings while ``all_day`` is a boolean flag.
+For ``office address`` content the attributes ``postal_code``, ``address``, ``phone``, ``fax`` and ``email`` store contact information.
 
 
 

--- a/tests/test_office_address_fields.py
+++ b/tests/test_office_address_fields.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import json
+import urllib.request
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cms.data import seed_users
+from cms.types import ContentType
+from cms.api import start_test_server
+
+
+@pytest.fixture()
+def users():
+    return seed_users()
+
+
+@pytest.fixture()
+def api_server():
+    server, thread = start_test_server()
+    base_url = f"http://localhost:{server.server_port}"
+    yield base_url
+    server.shutdown()
+    thread.join()
+
+
+@pytest.fixture()
+def auth_token(api_server):
+    status, body = _request(api_server, "POST", "/test-token", {"username": "tester"})
+    assert status == 200
+    return body["token"]
+
+
+def _request(base_url, method, path, data=None, token=None):
+    url = base_url + path
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if data is not None:
+        data = json.dumps(data).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode())
+
+
+def test_office_address_revisions_include_fields(api_server, auth_token, users):
+    content = {
+        "title": "Office",
+        "type": ContentType.OFFICE_ADDRESS.value,
+        "postal_code": "12345",
+        "address": "1 Main St",
+        "phone": "555-1111",
+        "fax": "555-2222",
+        "email": "a@example.com",
+        "created_by": users["editor"]["uuid"],
+        "created_at": "2025-06-09T12:00:00",
+        "timestamps": "2025-06-09T12:00:00",
+    }
+    status, body = _request(api_server, "POST", "/content", content, token=auth_token)
+    assert status == 201
+    item_uuid = body["uuid"]
+
+    updated = body.copy()
+    updated["title"] = "Updated Title"
+    status, body = _request(api_server, "PUT", f"/content/{item_uuid}", updated, token=auth_token)
+    assert status == 200
+
+    status, body = _request(api_server, "GET", f"/content/{item_uuid}", token=auth_token)
+    assert status == 200
+    for rev in body["revisions"]:
+        attrs = rev["attributes"]
+        assert "postal_code" in attrs
+        assert "address" in attrs
+        assert "phone" in attrs
+        assert "fax" in attrs
+        assert "email" in attrs

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -41,7 +41,15 @@ def _sample_content(content_type, users, idx):
     if content_type == ContentType.PDF.value:
         content["file_uuid"] = str(uuid.uuid4())
     elif content_type == ContentType.OFFICE_ADDRESS.value:
-        content["address"] = f"{idx} Example Rd." 
+        content.update(
+            {
+                "postal_code": f"000{idx}",
+                "address": f"{idx} Example Rd.",
+                "phone": "555-0000",
+                "fax": "555-0001",
+                "email": f"office{idx}@example.com",
+            }
+        )
     elif content_type == ContentType.EVENT_SCHEDULE.value:
         start = f"2025-06-{10 + idx:02d}T09:00:00"
         content["start"] = start


### PR DESCRIPTION
## Summary
- keep office address contact fields in every revision
- seed example office address data with contact info
- mention the new fields in the data structure docs
- ensure `_sample_content` used in publish tests supplies these fields
- test that office address revisions always contain the contact info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463ef59d1c8322aa49807e6f8fcc05